### PR TITLE
Outlier correction

### DIFF
--- a/df3dPostProcessing/df3dPostProcessing.py
+++ b/df3dPostProcessing/df3dPostProcessing.py
@@ -2,8 +2,8 @@ import numpy as np
 import os
 import pickle
 import scipy.signal
-from .utils.utils_alignment import align_3d
-from .utils.utils_angles import calculate_angles
+from df3dPostProcessing.utils.utils_alignment import align_3d
+from df3dPostProcessing.utils.utils_angles import calculate_angles
 #from .utils.utils_plots import *
 
 df3d_skeleton = ['RFCoxa',
@@ -212,7 +212,7 @@ class df3dPostProcess:
         self.data_2d_dict = load_data_to_dict(self.raw_data_2d, skeleton)
         self.aligned_model = {}
 
-    def align_to_template(self,scale=True,interpolate=False,smoothing=True,original_time_step= 0.01,new_time_step=0.001,window_length=29):
+    def align_to_template(self,scale=True,interpolate=False,smoothing=True,original_time_step= 0.01,new_time_step=0.001,window_length=11):
         self.aligned_model = align_3d(self.data_3d_dict,self.skeleton,self.template,scale,interpolate, smoothing, original_time_step, new_time_step, window_length)
 
         return self.aligned_model
@@ -260,7 +260,7 @@ class df3dPostProcess:
             data = np.load(exp,allow_pickle=True)
             if skeleton == 'prism':
                 data={'points3d':data}
-
+            #from IPython import embed; embed()
             if calculate_3d:
                 self.raw_data_3d = triangulate_2d(data, exp)
                 
@@ -269,7 +269,7 @@ class df3dPostProcess:
                     self.raw_data_cams[key] = vals
                 elif key == 'points3d':
                     if not calculate_3d:
-                        self.raw_data_3d = vals
+                        self.raw_data_3d = vals['points3d']
                 elif key == 'points2d':
                     self.raw_data_2d = vals
 

--- a/df3dPostProcessing/utils/utils_plots.py
+++ b/df3dPostProcessing/utils/utils_plots.py
@@ -1188,7 +1188,7 @@ def plot_SG_angles(angles,degrees=True):
     plt.show()
 
 def plot_3d_and_2d(data, plane='xz', begin=0,end=0,metric = 'raw_pos_aligned', savePlot = False, pause=False):
-    colors = {'RF':(1,0,0),'RM':(0,1,0),'RH':(0,0,1),'LF':(1,1,0),'LM':(1,0,1),'LH':(0,1,1)}
+    colors = {'RF':(1,0,0),'RM':(0,1,0),'RH':(0,0,1),'LF':(1,1,0),'LM':(1,0,1),'LH':(0,1,1),'He':(1,1,1)}
     if end == 0:
         end = len(data['LF_leg']['Coxa'][metric])
     fig_3d = plt.figure()
@@ -1202,7 +1202,7 @@ def plot_3d_and_2d(data, plane='xz', begin=0,end=0,metric = 'raw_pos_aligned', s
             ax_2d = plt.axes()
             
         for segment, landmark in data.items():
-            if 'L' in segment or 'R' in segment:
+            #if 'L' in segment or 'R' in segment:
                 x=[]
                 y=[]
                 z=[]

--- a/df3dPostProcessing/utils/utils_plots.py
+++ b/df3dPostProcessing/utils/utils_plots.py
@@ -6,11 +6,11 @@ import os
 from scipy.spatial.transform import Rotation as R
 from sklearn.metrics import mean_squared_error
 from sklearn import svm
-from . import utils_angles
+from df3dPostProcessing.utils import utils_angles
 import pandas as pd
 from scipy import stats
 from statsmodels.stats import weightstats as stests
-from .utils_angles import calculate_forward_kinematics
+from df3dPostProcessing.utils.utils_angles import calculate_forward_kinematics
 from ikpy.chain import Chain 
 from ikpy.link import OriginLink, URDFLink
 from matplotlib.legend_handler import HandlerTuple


### PR DESCRIPTION
Added Florian's outlier correction method to the main branch. Code checks if the lengths of leg segments vary much and then corrects those with high variation by finding the pair of cameras giving the smallest projection error and replacing the new keypoint position from these cameras with the outlier one. This method works as long as the triangulation is fine. If triangulation is erroneous from the start, then this method does not work. 

New usage is:

from df3dPostProcessing import df3dPostProcess

```
exp = 'path/to/NeuroMechFly/data/joint_tracking/walking or grooming/df3d/pose_result*.pkl'
df3d = df3dPostProcess(exp, calculate_3d=True,  correct_outliers=True)
align = df3d.align_to_template(interpolate=True, all_body=True)
angles = df3d.calculate_leg_angles()

```