### PR TITLE
Outlier correction

### DIFF
--- a/df3dPostProcessing/df3dPostProcessing.py
+++ b/df3dPostProcessing/df3dPostProcessing.py
@@ -1,3 +1,5 @@
+import itertools
+
 import numpy as np
 import os
 import pickle
@@ -7,6 +9,7 @@ from .utils.utils_alignment import align_3d
 from .utils.utils_angles import calculate_angles
 from .utils.utils_ball_info import ball_size_and_pos
 #from .utils.utils_plots import *
+import deepfly.signal_util
 
 df3d_skeleton = ['RFCoxa',
                  'RFFemur',
@@ -322,7 +325,129 @@ def triangulate_2d(data, exp_dir):
         camNet.cam_list[cam_id].set_tvec(data[cam_id]["tvec"]) 
     camNet.triangulate() 
 
+    camNet = correct_outliers(camNet)
+
     return camNet.points3d
+
+def correct_outliers(camNet):
+    from deepfly.cv_util import triangulate_linear
+
+    #outlier_image_ids = np.where(np.abs(camNet.points3d_m) > 5)[0]
+    #outlier_joint_ids = np.where(np.abs(camNet.points3d_m) > 5)[1]
+    #print(outlier_image_ids)
+    #print(outlier_joint_ids)
+
+    start_indices = np.array([0, 1, 2, 3,
+                              5, 6, 7, 8,
+                              10, 11, 12, 13,
+                              19, 20, 21, 22,
+                              24, 25, 26, 27,
+                              29, 30, 31, 32,],
+                             dtype=np.int)
+    stop_indices = start_indices + 1
+    #pairs = np.vstack((start_indices, stop_indices))
+    #lengths = np.sum((camNet.points3d_m[:, start_indices, :] - camNet.points3d_m[:, stop_indices, :]) ** 2, axis=2)
+    lengths = np.linalg.norm(camNet.points3d_m[:, start_indices, :] - camNet.points3d_m[:, stop_indices, :], axis=2)
+    median_lengths = np.median(lengths, axis=0)
+    #length_outliers = (lengths > np.quantile(lengths, 0.99, axis=0)) | (lengths < np.quantile(lengths, 0.01, axis=0))
+    length_outliers = (lengths > median_lengths * 1.4) | (lengths < median_lengths * 0.4)
+    #print(np.quantile(lengths, 0.99, axis=0))
+    #print(np.max(lengths, axis=0))
+    #print(np.quantile(lengths, 0.01, axis=0))
+    #print(np.min(lengths, axis=0))
+    outlier_mask = np.zeros(camNet.points3d_m.shape, dtype=np.bool)
+    for i, mask_offset in enumerate([0, 5, 10, 19, 24, 29]):
+        claw_outliers = np.where(length_outliers[:, i * 4 + 3] & ~length_outliers[:, i * 4 + 2])[0]
+        tarsus_outliers = np.where(length_outliers[:, i * 4 + 3] & length_outliers[:, i * 4 + 2])[0]
+        tibia_outliers = np.where(length_outliers[:, i * 4 + 2] & length_outliers[:, i * 4 + 1])[0]
+        femur_outliers = np.where(length_outliers[:, i * 4 + 1] & length_outliers[:, i * 4 + 0])[0]
+        outlier_mask[femur_outliers, 1 + mask_offset] = True
+        outlier_mask[tibia_outliers, 2 + mask_offset] = True
+        outlier_mask[tarsus_outliers, 3 + mask_offset] = True
+        outlier_mask[claw_outliers, 4 + mask_offset] = True
+    
+    outlier_image_ids = np.where(outlier_mask)[0]
+    outlier_joint_ids = np.where(outlier_mask)[1]
+    #print(outlier_image_ids)
+    #print(outlier_joint_ids)
+    #exit()
+    
+
+    def _triangluate_specific_cameras(camNet, cam_id_list,img_id, j_id):
+        cam_list_iter = list()
+        points2d_iter = list()
+        for cam in [camNet.cam_list[cam_idx] for cam_idx in cam_id_list]:
+            cam_list_iter.append(cam)
+            points2d_iter.append(cam[img_id, j_id, :])
+        return triangulate_linear(cam_list_iter, points2d_iter)
+
+    for img_id, joint_id in zip(outlier_image_ids, outlier_joint_ids):
+        reprojection_errors = list()
+        segment_length_diff = list()
+        points_using_2_cams = list()
+        # Select cameras based on which side the joint is on
+        all_cam_ids = [0, 1, 2] if joint_id < 19 else [4, 5, 6]
+        for subset_cam_ids in itertools.combinations(all_cam_ids, 2):
+            points3d_using_2_cams = _triangluate_specific_cameras(camNet, subset_cam_ids, img_id, joint_id)
+
+            new_diff = 0
+            median_index = np.where(stop_indices == joint_id)[0]
+            if len(median_index) > 0:
+                new_diff += np.linalg.norm(points3d_using_2_cams - camNet.points3d_m[img_id, joint_id - 1]) - median_lengths[median_index]
+            median_index = np.where(start_indices == joint_id)[0]
+            if len(median_index) > 0:
+                new_diff += np.linalg.norm(points3d_using_2_cams - camNet.points3d_m[img_id, joint_id + 1]) - median_lengths[median_index]
+            segment_length_diff.append(new_diff)
+
+            reprojection_error_function = lambda cam_id: camNet.cam_list[cam_id].project(points3d_using_2_cams) - camNet.cam_list[cam_id].points2d[img_id, joint_id]
+            reprojection_error = np.mean([reprojection_error_function(cam_id) for cam_id in subset_cam_ids])
+            reprojection_errors.append(reprojection_error)
+            points_using_2_cams.append(points3d_using_2_cams)
+
+        #reprojection_error_function = lambda cam_id: camNet.cam_list[cam_id].project(camNet.points3d_m[img_id, joint_id]) - camNet.cam_list[cam_id].points2d[img_id, joint_id]
+        #reprojection_error_3_cams = np.mean([reprojection_error_function(cam_id) for cam_id in all_cam_ids])
+
+        #if np.min(reprojection_errors) < reprojection_error_3_cams:
+        # Replace 3D points with best estimation from 2 cameras only
+        #best_cam_tuple_index = np.argmin(reprojection_errors)
+        best_cam_tuple_index = np.argmin(segment_length_diff)
+
+        old_diff = 0
+        new_diff = 0
+        median_index = np.where(stop_indices == joint_id)[0]
+        if len(median_index) > 0:
+            #print(pairs[:, median_index], joint_id, joint_id - 1)
+            old_diff += np.linalg.norm(camNet.points3d_m[img_id, joint_id] - camNet.points3d_m[img_id, joint_id - 1]) - median_lengths[median_index]
+            new_diff += np.linalg.norm(points_using_2_cams[best_cam_tuple_index] - camNet.points3d_m[img_id, joint_id - 1]) - median_lengths[median_index]
+        median_index = np.where(start_indices == joint_id)[0]
+        if len(median_index) > 0:
+            #print(pairs[:, median_index], joint_id, joint_id + 1)
+            old_diff += np.linalg.norm(camNet.points3d_m[img_id, joint_id] - camNet.points3d_m[img_id, joint_id + 1]) - median_lengths[median_index]
+            new_diff += np.linalg.norm(points_using_2_cams[best_cam_tuple_index] - camNet.points3d_m[img_id, joint_id + 1]) - median_lengths[median_index]
+
+        if new_diff < old_diff:
+            #print("correcting", img_id, joint_id)
+            camNet.points3d_m[img_id, joint_id] = points_using_2_cams[best_cam_tuple_index]
+        #else:
+        #    pass
+            #print("not correcting", img_id, joint_id, new_diff, old_diff)
+        #if img_id == 18957:
+        #    print(segment_length_diff)
+        #    print(new_diff)
+        #    print(old_diff)
+        #    exit()
+    #print(np.histogram(np.max(camNet.points3d_m[:, :, 0], axis=1)))
+    #exit()
+    #center_frame_index = np.argmax(np.max(camNet.points3d_m[:, :, 0], axis=1))
+    #center_frame_index = 12801
+    #center_frame_index = 18957
+    #print(center_frame_index)
+    #camNet.points3d_m = camNet.points3d_m[max(0, center_frame_index - 50):min(camNet.points3d_m.shape[0], center_frame_index + 50)]
+    #exit()
+    #print(camNet.points3d_m.shape)
+    camNet.points3d_m = deepfly.signal_util.filter_batch(camNet.points3d_m, freq=100)
+    return camNet
+
 
 def load_data_to_dict(data, skeleton):
     final_dict ={}

--- a/df3dPostProcessing/df3dPostProcessing.py
+++ b/df3dPostProcessing/df3dPostProcessing.py
@@ -357,7 +357,7 @@ def correct_outliers(camNet):
     #print(np.min(lengths, axis=0))
     outlier_mask = np.zeros(camNet.points3d.shape, dtype=np.bool)
     for i, mask_offset in enumerate([0, 5, 10, 19, 24, 29]):
-        claw_outliers = np.where(length_outliers[:, i * 4 + 3] & ~length_outliers[:, i * 4 + 2])[0]
+        claw_outliers = np.where(length_outliers[:, i * 4 + 4] & ~length_outliers[:, i * 4 + 3])[0]
         tarsus_outliers = np.where(length_outliers[:, i * 4 + 3] & length_outliers[:, i * 4 + 2])[0]
         tibia_outliers = np.where(length_outliers[:, i * 4 + 2] & length_outliers[:, i * 4 + 1])[0]
         femur_outliers = np.where(length_outliers[:, i * 4 + 1] & length_outliers[:, i * 4 + 0])[0]

--- a/df3dPostProcessing/df3dPostProcessing.py
+++ b/df3dPostProcessing/df3dPostProcessing.py
@@ -49,35 +49,35 @@ df3d_skeleton = ['RFCoxa',
                  'LStripe3']
 
 prism_skeleton_LP3D = ['LFCoxa',
-                  'LFFemur',
-                  'LFTibia',
-                  'LFTarsus',
-                  'LFClaw',
-                  'LMCoxa',
-                  'LMFemur',
-                  'LMTibia',
-                  'LMTarsus',
-                  'LMClaw',
-                  'LHCoxa',
-                  'LHFemur',
-                  'LHTibia',
-                  'LHTarsus',
-                  'LHClaw',
-                  'RFCoxa',
-                  'RFFemur',
-                  'RFTibia',
-                  'RFTarsus',
-                  'RFClaw',
-                  'RMCoxa',
-                  'RMFemur',
-                  'RMTibia',
-                  'RMTarsus',
-                  'RMClaw',
-                  'RHCoxa',
-                  'RHFemur',
-                  'RHTibia',
-                  'RHTarsus',
-                  'RHClaw']
+                       'LFFemur',
+                       'LFTibia',
+                       'LFTarsus',
+                       'LFClaw',
+                       'LMCoxa',
+                       'LMFemur',
+                       'LMTibia',
+                       'LMTarsus',
+                       'LMClaw',
+                       'LHCoxa',
+                       'LHFemur',
+                       'LHTibia',
+                       'LHTarsus',
+                       'LHClaw',
+                       'RFCoxa',
+                       'RFFemur',
+                       'RFTibia',
+                       'RFTarsus',
+                       'RFClaw',
+                       'RMCoxa',
+                       'RMFemur',
+                       'RMTibia',
+                       'RMTarsus',
+                       'RMClaw',
+                       'RHCoxa',
+                       'RHFemur',
+                       'RHTibia',
+                       'RHTarsus',
+                       'RHClaw']
 
 prism_skeleton = ['RFCoxa',
                   'RFFemur',
@@ -127,84 +127,92 @@ prism_skeleton = ['RFCoxa',
                   'A5',
                   'A6']
 
-template_nmf = {'RFCoxa':[0.35, -0.27, 0.400],
-                'RFFemur':[0.35, -0.27, -0.025],
-                'RFTibia':[0.35, -0.27, -0.731],
-                'RFTarsus':[0.35, -0.27, -1.249],
-                'RFClaw':[0.35, -0.27, -1.912],
-                'LFCoxa':[0.35, 0.27, 0.400],
-                'LFFemur':[0.35, 0.27, -0.025],
-                'LFTibia':[0.35, 0.27, -0.731],
-                'LFTarsus':[0.35, 0.27, -1.249],
-                'LFClaw':[0.35, 0.27, -1.912],
-                'RMCoxa':[0, -0.125, 0],
-                'RMFemur':[0, -0.125, -0.182],
-                'RMTibia':[0, -0.125, -0.965],
-                'RMTarsus':[0, -0.125, -1.633],
-                'RMClaw':[0, -0.125, -2.328],
-                'LMCoxa':[0, 0.125, 0],
-                'LMFemur':[0, 0.125, -0.182],
-                'LMTibia':[0, 0.125, -0.965],
-                'LMTarsus':[0, 0.125, -1.633],
-                'LMClaw':[0, 0.125, -2.328],                      
-                'RHCoxa':[-0.215, -0.087, -0.073],
-                'RHFemur':[-0.215, -0.087, -0.272],
-                'RHTibia':[-0.215, -0.087, -1.108],
-                'RHTarsus':[-0.215, -0.087, -1.793],
-                'RHClaw':[-0.215, -0.087, -2.588],                      
-                'LHCoxa':[-0.215, 0.087, -0.073],
-                'LHFemur':[-0.215, 0.087, -0.272],
-                'LHTibia':[-0.215, 0.087, -1.108],
-                'LHTarsus':[-0.215, 0.087, -1.793],
-                'LHClaw':[-0.215, 0.087, -2.588],
-                'RAntenna':[0.25, -0.068, 0.67],
-                'LAntenna':[0.25, 0.068, 0.67]}
+template_nmf = {'RFCoxa': [0.35, -0.27, 0.400],
+                'RFFemur': [0.35, -0.27, -0.025],
+                'RFTibia': [0.35, -0.27, -0.731],
+                'RFTarsus': [0.35, -0.27, -1.249],
+                'RFClaw': [0.35, -0.27, -1.912],
+                'LFCoxa': [0.35, 0.27, 0.400],
+                'LFFemur': [0.35, 0.27, -0.025],
+                'LFTibia': [0.35, 0.27, -0.731],
+                'LFTarsus': [0.35, 0.27, -1.249],
+                'LFClaw': [0.35, 0.27, -1.912],
+                'RMCoxa': [0, -0.125, 0],
+                'RMFemur': [0, -0.125, -0.182],
+                'RMTibia': [0, -0.125, -0.965],
+                'RMTarsus': [0, -0.125, -1.633],
+                'RMClaw': [0, -0.125, -2.328],
+                'LMCoxa': [0, 0.125, 0],
+                'LMFemur': [0, 0.125, -0.182],
+                'LMTibia': [0, 0.125, -0.965],
+                'LMTarsus': [0, 0.125, -1.633],
+                'LMClaw': [0, 0.125, -2.328],
+                'RHCoxa': [-0.215, -0.087, -0.073],
+                'RHFemur': [-0.215, -0.087, -0.272],
+                'RHTibia': [-0.215, -0.087, -1.108],
+                'RHTarsus': [-0.215, -0.087, -1.793],
+                'RHClaw': [-0.215, -0.087, -2.588],
+                'LHCoxa': [-0.215, 0.087, -0.073],
+                'LHFemur': [-0.215, 0.087, -0.272],
+                'LHTibia': [-0.215, 0.087, -1.108],
+                'LHTarsus': [-0.215, 0.087, -1.793],
+                'LHClaw': [-0.215, 0.087, -2.588],
+                'RAntenna': [0.25, -0.068, 0.67],
+                'LAntenna': [0.25, 0.068, 0.67]}
 
-zero_pose_nmf = {'RF_leg':{'ThC_yaw':0,
-                           'ThC_pitch':0,
-                           'ThC_roll':0,
-                           'CTr_roll':0,
-                           'CTr_pitch':-np.pi,
-                           'FTi_pitch':np.pi,
-                           'TiTa_pitch':-np.pi},
-                 'RM_leg':{'ThC_yaw':0,
-                           'ThC_pitch':0,
-                           'ThC_roll':-np.pi/2,
-                           'CTr_roll':0,
-                           'CTr_pitch':-np.pi,
-                           'FTi_pitch':np.pi,
-                           'TiTa_pitch':-np.pi},
-                 'RH_leg':{'ThC_yaw':0,
-                           'ThC_pitch':0,
-                           'ThC_roll':-np.pi,
-                           'CTr_roll':0,
-                           'CTr_pitch':-np.pi,
-                           'FTi_pitch':np.pi,
-                           'TiTa_pitch':-np.pi},
-                 'LF_leg':{'ThC_yaw':0,
-                           'ThC_pitch':0,
-                           'ThC_roll':0,
-                           'CTr_roll':0,
-                           'CTr_pitch':-np.pi,
-                           'FTi_pitch':np.pi,
-                           'TiTa_pitch':-np.pi},
-                 'LM_leg':{'ThC_yaw':0,
-                           'ThC_pitch':0,
-                           'ThC_roll':np.pi/2,
-                           'CTr_roll':0,
-                           'CTr_pitch':-np.pi,
-                           'FTi_pitch':np.pi,
-                           'TiTa_pitch':-np.pi},
-                 'LH_leg':{'ThC_yaw':0,
-                           'ThC_pitch':0,
-                           'ThC_roll':np.pi,
-                           'CTr_roll':0,
-                           'CTr_pitch':-np.pi,
-                           'FTi_pitch':np.pi,
-                           'TiTa_pitch':-np.pi}}
+zero_pose_nmf = {'RF_leg': {'ThC_yaw': 0,
+                            'ThC_pitch': 0,
+                            'ThC_roll': 0,
+                            'CTr_roll': 0,
+                            'CTr_pitch': -np.pi,
+                            'FTi_pitch': np.pi,
+                            'TiTa_pitch': -np.pi},
+                 'RM_leg': {'ThC_yaw': 0,
+                            'ThC_pitch': 0,
+                            'ThC_roll': -np.pi / 2,
+                            'CTr_roll': 0,
+                            'CTr_pitch': -np.pi,
+                            'FTi_pitch': np.pi,
+                            'TiTa_pitch': -np.pi},
+                 'RH_leg': {'ThC_yaw': 0,
+                            'ThC_pitch': 0,
+                            'ThC_roll': -np.pi,
+                            'CTr_roll': 0,
+                            'CTr_pitch': -np.pi,
+                            'FTi_pitch': np.pi,
+                            'TiTa_pitch': -np.pi},
+                 'LF_leg': {'ThC_yaw': 0,
+                            'ThC_pitch': 0,
+                            'ThC_roll': 0,
+                            'CTr_roll': 0,
+                            'CTr_pitch': -np.pi,
+                            'FTi_pitch': np.pi,
+                            'TiTa_pitch': -np.pi},
+                 'LM_leg': {'ThC_yaw': 0,
+                            'ThC_pitch': 0,
+                            'ThC_roll': np.pi / 2,
+                            'CTr_roll': 0,
+                            'CTr_pitch': -np.pi,
+                            'FTi_pitch': np.pi,
+                            'TiTa_pitch': -np.pi},
+                 'LH_leg': {'ThC_yaw': 0,
+                            'ThC_pitch': 0,
+                            'ThC_roll': np.pi,
+                            'CTr_roll': 0,
+                            'CTr_pitch': -np.pi,
+                            'FTi_pitch': np.pi,
+                            'TiTa_pitch': -np.pi}}
+
 
 class df3dPostProcess:
-    def __init__(self, exp_dir, multiple = False, file_name = '', skeleton='df3d', calculate_3d=False, outlier_correction=False):
+    def __init__(
+            self,
+            exp_dir,
+            multiple=False,
+            file_name='',
+            skeleton='df3d',
+            calculate_3d=False,
+            outlier_correction=False):
         self.exp_dir = exp_dir
         self.raw_data_3d = np.array([])
         self.raw_data_2d = np.array([])
@@ -212,96 +220,148 @@ class df3dPostProcess:
         self.template = template_nmf
         self.zero_pose = zero_pose_nmf
         self.raw_data_cams = {}
-        self.load_data(exp_dir, calculate_3d, skeleton, multiple, file_name, outlier_correction=outlier_correction)
+        self.load_data(
+            exp_dir,
+            calculate_3d,
+            skeleton,
+            multiple,
+            file_name,
+            outlier_correction=outlier_correction)
         self.data_3d_dict = load_data_to_dict(self.raw_data_3d, skeleton)
         self.data_2d_dict = load_data_to_dict(self.raw_data_2d, skeleton)
         self.aligned_model = {}
 
-    def align_to_template(self,scale='local',all_body=False,interpolate=False,smoothing=True,original_time_step= 0.01,new_time_step=0.001,window_length=29):
-        self.aligned_model = align_3d(self.data_3d_dict,self.skeleton,self.template,scale,all_body,interpolate, smoothing, original_time_step, new_time_step, window_length)
+    def align_to_template(
+            self,
+            scale='local',
+            all_body=False,
+            interpolate=False,
+            smoothing=True,
+            original_time_step=0.01,
+            new_time_step=0.001,
+            window_length=29):
+        self.aligned_model = align_3d(
+            self.data_3d_dict,
+            self.skeleton,
+            self.template,
+            scale,
+            all_body,
+            interpolate,
+            smoothing,
+            original_time_step,
+            new_time_step,
+            window_length)
 
         return self.aligned_model
 
-    def calculate_leg_angles(self, begin = 0, end = 0, get_CTr_roll = True, save_angles=False, use_zero_pose=True, zero_pose=None):
+    def calculate_leg_angles(
+            self,
+            begin=0,
+            end=0,
+            get_CTr_roll=True,
+            save_angles=False,
+            use_zero_pose=True,
+            zero_pose=None):
         if not zero_pose:
             zero_pose = self.zero_pose
-                
-        leg_angles = calculate_angles(self.aligned_model, begin, end, get_CTr_roll, zero_pose)
+
+        leg_angles = calculate_angles(
+            self.aligned_model, begin, end, get_CTr_roll, zero_pose)
 
         if use_zero_pose:
             for leg, angles in leg_angles.items():
                 for angle, vals in angles.items():
-                    leg_angles[leg][angle] = list(np.array(vals) + zero_pose[leg][angle])
-                
+                    leg_angles[leg][angle] = list(
+                        np.array(vals) + zero_pose[leg][angle])
+
         if save_angles:
             path = 'joint_angles.pkl'
             if self.skeleton == 'df3d':
-                path = self.exp_dir.replace('pose_result','joint_angles')
+                path = self.exp_dir.replace('pose_result', 'joint_angles')
             if self.skeleton == 'prism' or self.skeleton == 'lp3d':
                 folders = self.exp_dir.split('/')
                 parent = self.exp_dir[:self.exp_dir.find(folders[-1])]
-                path = os.path.join(parent,f"joint_angles__{folders[-1]}")
-                path = path.replace(".npy",".pkl")
-                
+                path = os.path.join(parent, f"joint_angles__{folders[-1]}")
+                path = path.replace(".npy", ".pkl")
+
             with open(path, 'wb') as f:
                 pickle.dump(leg_angles, f)
         return leg_angles
 
-    def calculate_velocity(self, data, window=11, order=3, time_step=0.001, save_velocities=False):
+    def calculate_velocity(
+            self,
+            data,
+            window=11,
+            order=3,
+            time_step=0.001,
+            save_velocities=False):
         velocities = {}
         for leg, angles in data.items():
-            velocities[leg]={}
+            velocities[leg] = {}
             for th, data in angles.items():
-                vel = scipy.signal.savgol_filter(data, window, order, deriv=1, delta=time_step, mode='nearest')
-                velocities[leg][th]=vel
+                vel = scipy.signal.savgol_filter(
+                    data, window, order, deriv=1, delta=time_step, mode='nearest')
+                velocities[leg][th] = vel
 
         if save_velocities:
             path = 'joint_velocities.pkl'
             if self.skeleton == 'df3d':
-                path = self.exp_dir.replace('pose_result','joint_velocities')
+                path = self.exp_dir.replace('pose_result', 'joint_velocities')
             if self.skeleton == 'prism' or self.skeleton == 'lp3d':
                 folders = self.exp_dir.split('/')
                 parent = self.exp_dir[:self.exp_dir.find(folders[-1])]
-                path = os.path.join(parent,f"joint_velocities__{folders[-1]}")
-                path = path.replace(".npy",".pkl")
-                
+                path = os.path.join(parent, f"joint_velocities__{folders[-1]}")
+                path = path.replace(".npy", ".pkl")
+
             with open(path, 'wb') as f:
                 pickle.dump(velocities, f)
-            
+
         return velocities
 
-    def get_treadmill_info(self, path=None, save_ball_info = False, show_detection=False):
+    def get_treadmill_info(
+            self,
+            path=None,
+            save_ball_info=False,
+            show_detection=False):
         if not path:
             data_path = self.exp_dir
         else:
             data_path = path
-        
+
         ball_radius, ball_pos = ball_size_and_pos(data_path, show_detection)
 
-        ball_info = {'radius':ball_radius, 'position':ball_pos}
+        ball_info = {'radius': ball_radius, 'position': ball_pos}
 
         if save_ball_info:
-            path = self.exp_dir.replace('pose_result','treadmill_info')
+            path = self.exp_dir.replace('pose_result', 'treadmill_info')
             with open(path, 'wb') as f:
                 pickle.dump(ball_info, f)
 
         return ball_info
-    
-    def load_data(self, exp, calculate_3d, skeleton, multiple, file_name, outlier_correction):
+
+    def load_data(
+            self,
+            exp,
+            calculate_3d,
+            skeleton,
+            multiple,
+            file_name,
+            outlier_correction):
         if multiple:
             currentDirectory = os.getcwd()
-            dataFile = os.path.join(currentDirectory,file_name)
-            data = np.load(dataFile,allow_pickle=True)
-            self.raw_data_3d  = data[exp]
+            dataFile = os.path.join(currentDirectory, file_name)
+            data = np.load(dataFile, allow_pickle=True)
+            self.raw_data_3d = data[exp]
         else:
-            data = np.load(exp,allow_pickle=True)
+            data = np.load(exp, allow_pickle=True)
             if skeleton == 'prism' or skeleton == 'lp3d':
-                data={'points3d_wo_procrustes':data}
+                data = {'points3d_wo_procrustes': data}
             if calculate_3d:
-                self.raw_data_3d = triangulate_2d(data, exp, outlier_correction)
-                
+                self.raw_data_3d = triangulate_2d(
+                    data, exp, outlier_correction)
+
             for key, vals in data.items():
-                if not isinstance(key,str):
+                if not isinstance(key, str):
                     self.raw_data_cams[key] = vals
                 elif key == 'points3d_wo_procrustes':
                     if not calculate_3d:
@@ -309,27 +369,32 @@ class df3dPostProcess:
                 elif key == 'points2d':
                     self.raw_data_2d = vals
 
+
 def triangulate_2d(data, exp_dir, outlier_correction):
     img_folder = exp_dir[:exp_dir.find('df3d')]
     out_folder = exp_dir[:exp_dir.find('pose_result')]
     num_images = data['points3d'].shape[0]
-    
-    from deepfly.CameraNetwork import CameraNetwork
-    camNet = CameraNetwork(image_folder=img_folder, output_folder=out_folder, num_images=num_images)
 
-    for cam_id in range(7): 
-        camNet.cam_list[cam_id].set_intrinsic(data[cam_id]["intr"]) 
-        camNet.cam_list[cam_id].set_R(data[cam_id]["R"]) 
-        camNet.cam_list[cam_id].set_tvec(data[cam_id]["tvec"]) 
-    camNet.triangulate() 
+    from deepfly.CameraNetwork import CameraNetwork
+    camNet = CameraNetwork(
+        image_folder=img_folder,
+        output_folder=out_folder,
+        num_images=num_images)
+
+    for cam_id in range(7):
+        camNet.cam_list[cam_id].set_intrinsic(data[cam_id]["intr"])
+        camNet.cam_list[cam_id].set_R(data[cam_id]["R"])
+        camNet.cam_list[cam_id].set_tvec(data[cam_id]["tvec"])
+    camNet.triangulate()
 
     if outlier_correction:
         camNet = correct_outliers(camNet)
 
     return camNet.points3d
 
+
 def load_data_to_dict(data, skeleton):
-    final_dict ={}
+    final_dict = {}
     if len(data.shape) == 3:
         time_pts, body_parts, axes = data.shape
         num_cams = 1
@@ -338,14 +403,14 @@ def load_data_to_dict(data, skeleton):
         cams_dict = {}
     else:
         return final_dict
-    
+
     if skeleton == 'prism':
         tracked_joints = prism_skeleton
     elif skeleton == 'df3d':
         tracked_joints = df3d_skeleton
     elif skeleton == 'lp3d':
         tracked_joints = prism_skeleton_LP3D
-   
+
     if body_parts != len(tracked_joints):
         raise Exception("Check tracked joints definition")
 
@@ -360,31 +425,25 @@ def load_data_to_dict(data, skeleton):
                 body_part = name[0:2] + '_leg'
                 landmark = name[2:]
             else:
-                if 'Antenna' in name or 'Neck' in name or 'Proboscis' in name or 'Eye' in name: 
+                if 'Antenna' in name or 'Neck' in name or 'Proboscis' in name or 'Eye' in name:
                     body_part = 'Head'
                 elif 'Haltere' in name or 'Wing' in name or 'Scutellum' in name:
                     body_part = 'Thorax'
                 elif 'Stripe' in name or 'Genitalia' in name or 'A1A2' in name or 'A3' in name or 'A4' in name or 'A5' in name or 'A6' in name:
                     body_part = 'Abdomen'
                 landmark = name
-                
+
             if body_part not in exp_dict.keys():
                 exp_dict[body_part] = {}
 
-            exp_dict[body_part][landmark] = coords[:,i,:]
+            exp_dict[body_part][landmark] = coords[:, i, :]
 
-        if num_cams>1:
+        if num_cams > 1:
             cams_dict[cam] = exp_dict
 
-    if num_cams>1:
+    if num_cams > 1:
         final_dict = cams_dict
     else:
         final_dict = exp_dict
-        
+
     return final_dict
-
-
-
-
-
-

--- a/df3dPostProcessing/df3dPostProcessing.py
+++ b/df3dPostProcessing/df3dPostProcessing.py
@@ -324,7 +324,6 @@ def triangulate_2d(data, exp_dir, outlier_correction):
     camNet.triangulate() 
 
     if outlier_correction:
-        print("correcting")
         camNet = correct_outliers(camNet)
 
     return camNet.points3d

--- a/df3dPostProcessing/df3dPostProcessing.py
+++ b/df3dPostProcessing/df3dPostProcessing.py
@@ -332,8 +332,8 @@ def triangulate_2d(data, exp_dir):
 def correct_outliers(camNet):
     from deepfly.cv_util import triangulate_linear
 
-    #outlier_image_ids = np.where(np.abs(camNet.points3d_m) > 5)[0]
-    #outlier_joint_ids = np.where(np.abs(camNet.points3d_m) > 5)[1]
+    #outlier_image_ids = np.where(np.abs(camNet.points3d) > 5)[0]
+    #outlier_joint_ids = np.where(np.abs(camNet.points3d) > 5)[1]
     #print(outlier_image_ids)
     #print(outlier_joint_ids)
 
@@ -346,8 +346,8 @@ def correct_outliers(camNet):
                              dtype=np.int)
     stop_indices = start_indices + 1
     #pairs = np.vstack((start_indices, stop_indices))
-    #lengths = np.sum((camNet.points3d_m[:, start_indices, :] - camNet.points3d_m[:, stop_indices, :]) ** 2, axis=2)
-    lengths = np.linalg.norm(camNet.points3d_m[:, start_indices, :] - camNet.points3d_m[:, stop_indices, :], axis=2)
+    #lengths = np.sum((camNet.points3d[:, start_indices, :] - camNet.points3d[:, stop_indices, :]) ** 2, axis=2)
+    lengths = np.linalg.norm(camNet.points3d[:, start_indices, :] - camNet.points3d[:, stop_indices, :], axis=2)
     median_lengths = np.median(lengths, axis=0)
     #length_outliers = (lengths > np.quantile(lengths, 0.99, axis=0)) | (lengths < np.quantile(lengths, 0.01, axis=0))
     length_outliers = (lengths > median_lengths * 1.4) | (lengths < median_lengths * 0.4)
@@ -355,7 +355,7 @@ def correct_outliers(camNet):
     #print(np.max(lengths, axis=0))
     #print(np.quantile(lengths, 0.01, axis=0))
     #print(np.min(lengths, axis=0))
-    outlier_mask = np.zeros(camNet.points3d_m.shape, dtype=np.bool)
+    outlier_mask = np.zeros(camNet.points3d.shape, dtype=np.bool)
     for i, mask_offset in enumerate([0, 5, 10, 19, 24, 29]):
         claw_outliers = np.where(length_outliers[:, i * 4 + 3] & ~length_outliers[:, i * 4 + 2])[0]
         tarsus_outliers = np.where(length_outliers[:, i * 4 + 3] & length_outliers[:, i * 4 + 2])[0]
@@ -393,10 +393,10 @@ def correct_outliers(camNet):
             new_diff = 0
             median_index = np.where(stop_indices == joint_id)[0]
             if len(median_index) > 0:
-                new_diff += np.linalg.norm(points3d_using_2_cams - camNet.points3d_m[img_id, joint_id - 1]) - median_lengths[median_index]
+                new_diff += np.linalg.norm(points3d_using_2_cams - camNet.points3d[img_id, joint_id - 1]) - median_lengths[median_index]
             median_index = np.where(start_indices == joint_id)[0]
             if len(median_index) > 0:
-                new_diff += np.linalg.norm(points3d_using_2_cams - camNet.points3d_m[img_id, joint_id + 1]) - median_lengths[median_index]
+                new_diff += np.linalg.norm(points3d_using_2_cams - camNet.points3d[img_id, joint_id + 1]) - median_lengths[median_index]
             segment_length_diff.append(new_diff)
 
             reprojection_error_function = lambda cam_id: camNet.cam_list[cam_id].project(points3d_using_2_cams) - camNet.cam_list[cam_id].points2d[img_id, joint_id]
@@ -404,7 +404,7 @@ def correct_outliers(camNet):
             reprojection_errors.append(reprojection_error)
             points_using_2_cams.append(points3d_using_2_cams)
 
-        #reprojection_error_function = lambda cam_id: camNet.cam_list[cam_id].project(camNet.points3d_m[img_id, joint_id]) - camNet.cam_list[cam_id].points2d[img_id, joint_id]
+        #reprojection_error_function = lambda cam_id: camNet.cam_list[cam_id].project(camNet.points3d[img_id, joint_id]) - camNet.cam_list[cam_id].points2d[img_id, joint_id]
         #reprojection_error_3_cams = np.mean([reprojection_error_function(cam_id) for cam_id in all_cam_ids])
 
         #if np.min(reprojection_errors) < reprojection_error_3_cams:
@@ -417,17 +417,17 @@ def correct_outliers(camNet):
         median_index = np.where(stop_indices == joint_id)[0]
         if len(median_index) > 0:
             #print(pairs[:, median_index], joint_id, joint_id - 1)
-            old_diff += np.linalg.norm(camNet.points3d_m[img_id, joint_id] - camNet.points3d_m[img_id, joint_id - 1]) - median_lengths[median_index]
-            new_diff += np.linalg.norm(points_using_2_cams[best_cam_tuple_index] - camNet.points3d_m[img_id, joint_id - 1]) - median_lengths[median_index]
+            old_diff += np.linalg.norm(camNet.points3d[img_id, joint_id] - camNet.points3d[img_id, joint_id - 1]) - median_lengths[median_index]
+            new_diff += np.linalg.norm(points_using_2_cams[best_cam_tuple_index] - camNet.points3d[img_id, joint_id - 1]) - median_lengths[median_index]
         median_index = np.where(start_indices == joint_id)[0]
         if len(median_index) > 0:
             #print(pairs[:, median_index], joint_id, joint_id + 1)
-            old_diff += np.linalg.norm(camNet.points3d_m[img_id, joint_id] - camNet.points3d_m[img_id, joint_id + 1]) - median_lengths[median_index]
-            new_diff += np.linalg.norm(points_using_2_cams[best_cam_tuple_index] - camNet.points3d_m[img_id, joint_id + 1]) - median_lengths[median_index]
+            old_diff += np.linalg.norm(camNet.points3d[img_id, joint_id] - camNet.points3d[img_id, joint_id + 1]) - median_lengths[median_index]
+            new_diff += np.linalg.norm(points_using_2_cams[best_cam_tuple_index] - camNet.points3d[img_id, joint_id + 1]) - median_lengths[median_index]
 
         if new_diff < old_diff:
             #print("correcting", img_id, joint_id)
-            camNet.points3d_m[img_id, joint_id] = points_using_2_cams[best_cam_tuple_index]
+            camNet.points3d[img_id, joint_id] = points_using_2_cams[best_cam_tuple_index]
         #else:
         #    pass
             #print("not correcting", img_id, joint_id, new_diff, old_diff)
@@ -436,16 +436,16 @@ def correct_outliers(camNet):
         #    print(new_diff)
         #    print(old_diff)
         #    exit()
-    #print(np.histogram(np.max(camNet.points3d_m[:, :, 0], axis=1)))
+    #print(np.histogram(np.max(camNet.points3d[:, :, 0], axis=1)))
     #exit()
-    #center_frame_index = np.argmax(np.max(camNet.points3d_m[:, :, 0], axis=1))
+    #center_frame_index = np.argmax(np.max(camNet.points3d[:, :, 0], axis=1))
     #center_frame_index = 12801
     #center_frame_index = 18957
     #print(center_frame_index)
-    #camNet.points3d_m = camNet.points3d_m[max(0, center_frame_index - 50):min(camNet.points3d_m.shape[0], center_frame_index + 50)]
+    #camNet.points3d = camNet.points3d[max(0, center_frame_index - 50):min(camNet.points3d.shape[0], center_frame_index + 50)]
     #exit()
-    #print(camNet.points3d_m.shape)
-    camNet.points3d_m = deepfly.signal_util.filter_batch(camNet.points3d_m, freq=100)
+    #print(camNet.points3d.shape)
+    camNet.points3d = deepfly.signal_util.filter_batch(camNet.points3d, freq=100)
     return camNet
 
 

--- a/df3dPostProcessing/utils/utils_angles.py
+++ b/df3dPostProcessing/utils/utils_angles.py
@@ -2,18 +2,19 @@ import numpy as np
 from mpl_toolkits.mplot3d import Axes3D
 from scipy.spatial.transform import Rotation as R
 
+
 def angle_between_segments(prev_joint, joint, next_joint, rot_axis):
     v1 = prev_joint - joint
     v2 = next_joint - joint
-    #print(v1)
-    #print(v2)
+    # print(v1)
+    # print(v2)
     try:
         cos_angle = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
-    except:
+    except BaseException:
         cos_angle = 0
     angle = np.arccos(cos_angle)
 
-    det = np.linalg.det([rot_axis,v1,v2,])
+    det = np.linalg.det([rot_axis, v1, v2, ])
     if det < 0:
         angle_corr = -angle
     else:
@@ -21,92 +22,96 @@ def angle_between_segments(prev_joint, joint, next_joint, rot_axis):
 
     return angle_corr
 
+
 def calculate_yaw(coxa_origin, femur_pos):
     next_joint = femur_pos.copy()
     next_joint[0] = coxa_origin[0]
-    z_axis = coxa_origin + [0,0,-1]
-    rot_axis = [1,0,0]
+    z_axis = coxa_origin + [0, 0, -1]
+    rot_axis = [1, 0, 0]
 
     angle = angle_between_segments(z_axis, coxa_origin, next_joint, rot_axis)
 
     return angle
+
 
 def calculate_pitch(coxa_origin, femur_pos):
     next_joint = femur_pos.copy()
     next_joint[1] = coxa_origin[1]
-    z_axis = coxa_origin + [0,0,-1]
-    rot_axis = [0,1,0]
-    
+    z_axis = coxa_origin + [0, 0, -1]
+    rot_axis = [0, 1, 0]
+
     angle = angle_between_segments(z_axis, coxa_origin, next_joint, rot_axis)
 
     return angle
 
-def calculate_roll(coxa_origin,femur_pos,tibia_pos,r,leg):
+
+def calculate_roll(coxa_origin, femur_pos, tibia_pos, r, leg):
     #length = np.linalg.norm(femur_pos-coxa_origin)
-    
+
     if 'RF' in leg:
-        prev_joint = np.array([1,0,0])
+        prev_joint = np.array([1, 0, 0])
         #rot_axis = [0,0,1]
     elif 'RM' in leg:
-        prev_joint = np.array([0,-1,0])
+        prev_joint = np.array([0, -1, 0])
         #rot_axis = [0,0,1]
     elif 'RH' in leg:
-        prev_joint = np.array([-1,0,0])
+        prev_joint = np.array([-1, 0, 0])
         #rot_axis = [0,0,1]
     elif 'LF' in leg:
-        prev_joint = np.array([1,0,0])
+        prev_joint = np.array([1, 0, 0])
         #rot_axis = [0,0,1]
     elif 'LM' in leg:
-        prev_joint = np.array([0,1,0])
+        prev_joint = np.array([0, 1, 0])
         #rot_axis = [0,0,1]
     elif 'LH' in leg:
-        prev_joint = np.array([-1,0,0])
+        prev_joint = np.array([-1, 0, 0])
 
-    rot_axis = [0,0,1]
-        
-    curr_joint = np.array([0,0,0])
+    rot_axis = [0, 0, 1]
+
+    curr_joint = np.array([0, 0, 0])
     r_inv = r.inv()
     tibia = tibia_pos - coxa_origin
     next_joint = r_inv.apply(tibia)
     next_joint[2] = 0
-    
 
-    angle = angle_between_segments(prev_joint,curr_joint,next_joint,rot_axis)
+    angle = angle_between_segments(
+        prev_joint, curr_joint, next_joint, rot_axis)
 
-    #if 'LF' in leg and angle<-np.pi/2:
+    # if 'LF' in leg and angle<-np.pi/2:
     #    angle = np.deg2rad(-110)
-    #elif 'RF' in leg and angle>np.pi/2:
+    # elif 'RF' in leg and angle>np.pi/2:
     #    angle -= np.pi/2
 
     return angle
 
-def calculate_roll_trochanter(leg_name, angles, data_dict,frame,zero_pose):
+
+def calculate_roll_trochanter(leg_name, angles, data_dict, frame, zero_pose):
     leg_angles = angles[leg_name]
 
     if 'RF' in leg_name:
-        rot_axis = [-1,0,0]    
+        rot_axis = [-1, 0, 0]
     elif 'RM' in leg_name:
-        rot_axis = [0,1,0]
+        rot_axis = [0, 1, 0]
     elif 'RH' in leg_name:
-        rot_axis = [1,0,0]
+        rot_axis = [1, 0, 0]
     elif 'LF' in leg_name:
-        rot_axis = [-1,0,0]
+        rot_axis = [-1, 0, 0]
     elif 'LM' in leg_name:
-        rot_axis = [0,-1,0]
+        rot_axis = [0, -1, 0]
     elif 'LH' in leg_name:
-        rot_axis = [1,0,0]
+        rot_axis = [1, 0, 0]
 
     yaw = leg_angles['ThC_yaw'][frame] + zero_pose[leg_name]['ThC_yaw']
     pitch = leg_angles['ThC_pitch'][frame] + zero_pose[leg_name]['ThC_pitch']
     roll = leg_angles['ThC_roll'][frame] + zero_pose[leg_name]['ThC_roll']
     th_fe = leg_angles['CTr_pitch'][frame] + zero_pose[leg_name]['CTr_pitch']
     th_ti = leg_angles['FTi_pitch'][frame] + zero_pose[leg_name]['FTi_pitch']
-    
-    r1 = R.from_euler('zyx',[roll,pitch,yaw])
-    r2 = R.from_euler('zyx',[0,th_fe,0])
-    r3 = R.from_euler('y',th_ti)
 
-    coxa_pos = data_dict['Coxa']['fixed_pos_aligned']    
+    r1 = R.from_euler('zyx', [roll, pitch, yaw])
+    r2 = R.from_euler('zyx', [0, th_fe, 0])
+    r3 = R.from_euler('y', th_ti)
+
+    coxa_pos = data_dict['Coxa']['fixed_pos_aligned']
     l_coxa = data_dict['Coxa']['mean_length']
     l_femur = data_dict['Femur']['mean_length']
     l_tibia = data_dict['Tibia']['mean_length']
@@ -114,115 +119,132 @@ def calculate_roll_trochanter(leg_name, angles, data_dict,frame,zero_pose):
     real_pos_femur = data_dict['Femur']['raw_pos_aligned'][frame]
     real_pos_tibia = data_dict['Tibia']['raw_pos_aligned'][frame]
     real_pos_tarsus = data_dict['Tarsus']['raw_pos_aligned'][frame]
-    
-    fe_init_pos = np.array([0,0,-l_coxa])
-    ti_init_pos = np.array([0,0,-l_femur])
-    ta_init_pos = np.array([0,0,-l_tibia])   
+
+    fe_init_pos = np.array([0, 0, -l_coxa])
+    ti_init_pos = np.array([0, 0, -l_femur])
+    ta_init_pos = np.array([0, 0, -l_tibia])
 
     femur_pos = r1.apply(fe_init_pos) + coxa_pos
-    tibia_pos = r1.apply(r2.apply(ti_init_pos)) + real_pos_femur         
-    tarsus_pos = r1.apply(r2.apply(r3.apply(ta_init_pos))) + real_pos_tibia    
+    tibia_pos = r1.apply(r2.apply(ti_init_pos)) + real_pos_femur
+    tarsus_pos = r1.apply(r2.apply(r3.apply(ta_init_pos))) + real_pos_tibia
 
-    angle = angle_between_segments(tarsus_pos,real_pos_tibia,real_pos_tarsus,rot_axis)
+    angle = angle_between_segments(
+        tarsus_pos,
+        real_pos_tibia,
+        real_pos_tarsus,
+        rot_axis)
 
     return angle
-    
-def calculate_angles(aligned_dict,begin,end,get_CTr_roll,zero_pose):
+
+
+def calculate_angles(aligned_dict, begin, end, get_CTr_roll, zero_pose):
     angles_dict = {}
     if end == 0:
         end = len(aligned_dict['RF_leg']['Coxa']['raw_pos_aligned'])
     for leg, joints in aligned_dict.items():
-        angles_dict[leg]={}
+        angles_dict[leg] = {}
         if 'F' in leg:
-            flex_axis = [0,1,0]
+            flex_axis = [0, 1, 0]
         elif 'RM' in leg:
-            flex_axis = [1,0,0]
+            flex_axis = [1, 0, 0]
         elif 'RH' in leg:
-            flex_axis = [0,-1,0]
+            flex_axis = [0, -1, 0]
         elif 'LM' in leg:
-            flex_axis = [-1,0,0]
+            flex_axis = [-1, 0, 0]
         elif 'LH' in leg:
-            flex_axis = [0,-1,0]
+            flex_axis = [0, -1, 0]
         for joint, data in joints.items():
             angles = []
             if 'Coxa' in joint:
-                angles_dict[leg]['ThC_yaw']=[]
-                angles_dict[leg]['ThC_pitch']=[]
-                angles_dict[leg]['ThC_roll']=[]
+                angles_dict[leg]['ThC_yaw'] = []
+                angles_dict[leg]['ThC_pitch'] = []
+                angles_dict[leg]['ThC_roll'] = []
                 coxa_origin = data['fixed_pos_aligned']
                 coxa_length = data['mean_length']
-                joints['Femur']['recal_pos']=[]
-                for i in range(begin,end):
+                joints['Femur']['recal_pos'] = []
+                for i in range(begin, end):
                     femur_pos = joints['Femur']['raw_pos_aligned'][i]
-                    yaw = calculate_yaw(coxa_origin,femur_pos)
-                    pitch = calculate_pitch(coxa_origin,femur_pos)
+                    yaw = calculate_yaw(coxa_origin, femur_pos)
+                    pitch = calculate_pitch(coxa_origin, femur_pos)
                     tibia_pos = joints['Tibia']['raw_pos_aligned'][i]
-                    r = R.from_euler('zyx', [0,pitch,yaw])
-                    roll = calculate_roll(coxa_origin,femur_pos,tibia_pos,r,leg)
-                    
+                    r = R.from_euler('zyx', [0, pitch, yaw])
+                    roll = calculate_roll(
+                        coxa_origin, femur_pos, tibia_pos, r, leg)
+
                     angles_dict[leg]['ThC_yaw'].append(yaw)
                     angles_dict[leg]['ThC_pitch'].append(pitch)
                     angles_dict[leg]['ThC_roll'].append(roll)
-                    
+
             if 'Femur' in joint:
-                angles_dict[leg]['CTr_pitch']=[]
-                for i in range(begin,end):
+                angles_dict[leg]['CTr_pitch'] = []
+                for i in range(begin, end):
                     #origin = data['recal_pos'][i]
                     coxa_pos = joints['Coxa']['fixed_pos_aligned']
                     femur_pos = data['raw_pos_aligned'][i]
-                    tibia_pos = joints['Tibia']['raw_pos_aligned'][i]                        
-                    th_femur = angle_between_segments(coxa_pos, femur_pos, tibia_pos,flex_axis)
-                    if th_femur<0:
+                    tibia_pos = joints['Tibia']['raw_pos_aligned'][i]
+                    th_femur = angle_between_segments(
+                        coxa_pos, femur_pos, tibia_pos, flex_axis)
+                    if th_femur < 0:
                         th_femur = -th_femur
                     angles_dict[leg]['CTr_pitch'].append(th_femur)
-                    
+
             if 'Tibia' in joint:
-                angles_dict[leg]['FTi_pitch']=[]
+                angles_dict[leg]['FTi_pitch'] = []
                 if get_CTr_roll:
-                    angles_dict[leg]['CTr_roll']=[]
-                for i in range(begin,end):
+                    angles_dict[leg]['CTr_roll'] = []
+                for i in range(begin, end):
                     #origin = data['recal_pos'][i]
                     femur_pos = joints['Femur']['raw_pos_aligned'][i]
                     tibia_pos = data['raw_pos_aligned'][i]
                     tarsus_pos = joints['Tarsus']['raw_pos_aligned'][i]
-                    th_tibia = angle_between_segments(femur_pos, tibia_pos, tarsus_pos,flex_axis)
-                    if th_tibia>0:
+                    th_tibia = angle_between_segments(
+                        femur_pos, tibia_pos, tarsus_pos, flex_axis)
+                    if th_tibia > 0:
                         th_tibia = -th_tibia
                     angles_dict[leg]['FTi_pitch'].append(th_tibia)
-                    
+
                     if get_CTr_roll:
-                        roll_tr = calculate_roll_trochanter(leg,angles_dict,joints,i-begin,zero_pose)
-                        if ('RF' in leg and roll_tr>0) or ('LF' in leg and roll_tr<0):
+                        roll_tr = calculate_roll_trochanter(
+                            leg, angles_dict, joints, i - begin, zero_pose)
+                        if ('RF' in leg and roll_tr > 0) or (
+                                'LF' in leg and roll_tr < 0):
                             roll_tr = -roll_tr
-                        elif ('RM' in leg and roll_tr>0) or ('LM' in leg and roll_tr<0):
+                        elif ('RM' in leg and roll_tr > 0) or ('LM' in leg and roll_tr < 0):
                             roll_tr = -roll_tr
-                        elif ('RH' in leg and roll_tr<0):# or ('LH' in leg and roll_tr>0):
+                        # or ('LH' in leg and roll_tr>0):
+                        elif ('RH' in leg and roll_tr < 0):
                             roll_tr = -roll_tr
                         angles_dict[leg]['CTr_roll'].append(roll_tr)
-                        
+
             if 'Tarsus' in joint:
-                angles_dict[leg]['TiTa_pitch']=[]
-                for i in range(begin,end):
+                angles_dict[leg]['TiTa_pitch'] = []
+                for i in range(begin, end):
                     tibia_pos = joints['Tibia']['raw_pos_aligned'][i]
                     tarsus_pos = data['raw_pos_aligned'][i]
                     claw_pos = joints['Claw']['raw_pos_aligned'][i]
-                    th_tarsus = angle_between_segments(tibia_pos, tarsus_pos, claw_pos,flex_axis)
-                    if th_tarsus<0:
+                    th_tarsus = angle_between_segments(
+                        tibia_pos, tarsus_pos, claw_pos, flex_axis)
+                    if th_tarsus < 0:
                         th_tarsus = -th_tarsus
                     angles_dict[leg]['TiTa_pitch'].append(th_tarsus)
 
     return angles_dict
 
 
-def calculate_forward_kinematics(leg_name, frame, leg_angles, data_dict, extraDOF={}):
-    
+def calculate_forward_kinematics(
+        leg_name,
+        frame,
+        leg_angles,
+        data_dict,
+        extraDOF={}):
+
     yaw = leg_angles['ThC_yaw'][frame]
     pitch = leg_angles['ThC_pitch'][frame]
     roll = leg_angles['ThC_roll'][frame]
     th_fe = leg_angles['CTr_pitch'][frame]
     th_ti = leg_angles['FTi_pitch'][frame]
     th_ta = leg_angles['TiTa_pitch'][frame]
-        
+
     roll_tr = 0
     yaw_tr = 0
     roll_ti = 0
@@ -243,32 +265,40 @@ def calculate_forward_kinematics(leg_name, frame, leg_angles, data_dict, extraDO
             if key == 'TiTa_roll':
                 roll_ta = val
             if key == 'TiTa_yaw':
-                yaw_ta = val           
-    
-    r1 = R.from_euler('zyx',[roll,pitch,yaw])
-    r2 = R.from_euler('zyx',[roll_tr,th_fe,yaw_tr])
-    r3 = R.from_euler('zyx',[roll_ti,th_ti,yaw_ti])
-    r4 = R.from_euler('zyx',[roll_ta,th_ta,yaw_ta])
+                yaw_ta = val
 
-    coxa_pos = data_dict[leg_name]['Coxa']['fixed_pos_aligned']    
-    l_coxa = data_dict[leg_name]['Coxa']['mean_length']#np.linalg.norm(coxa_pos-real_pos_femur)#
-    l_femur = data_dict[leg_name]['Femur']['mean_length']#np.linalg.norm(real_pos_femur-real_pos_tibia)#
-    l_tibia = data_dict[leg_name]['Tibia']['mean_length']#np.linalg.norm(real_pos_tibia-real_pos_tarsus)#
-    l_tarsus = data_dict[leg_name]['Tarsus']['mean_length']#np.linalg.norm(real_pos_tarsus-real_pos_claw)#
+    r1 = R.from_euler('zyx', [roll, pitch, yaw])
+    r2 = R.from_euler('zyx', [roll_tr, th_fe, yaw_tr])
+    r3 = R.from_euler('zyx', [roll_ti, th_ti, yaw_ti])
+    r4 = R.from_euler('zyx', [roll_ta, th_ta, yaw_ta])
 
-    fe_init_pos = np.array([0,0,-l_coxa])
-    ti_init_pos = np.array([0,0,-l_femur])
-    ta_init_pos = np.array([0,0,-l_tibia])
-    claw_init_pos = np.array([0,0,-l_tarsus])
+    coxa_pos = data_dict[leg_name]['Coxa']['fixed_pos_aligned']
+    # np.linalg.norm(coxa_pos-real_pos_femur)#
+    l_coxa = data_dict[leg_name]['Coxa']['mean_length']
+    # np.linalg.norm(real_pos_femur-real_pos_tibia)#
+    l_femur = data_dict[leg_name]['Femur']['mean_length']
+    # np.linalg.norm(real_pos_tibia-real_pos_tarsus)#
+    l_tibia = data_dict[leg_name]['Tibia']['mean_length']
+    # np.linalg.norm(real_pos_tarsus-real_pos_claw)#
+    l_tarsus = data_dict[leg_name]['Tarsus']['mean_length']
+
+    fe_init_pos = np.array([0, 0, -l_coxa])
+    ti_init_pos = np.array([0, 0, -l_femur])
+    ta_init_pos = np.array([0, 0, -l_tibia])
+    claw_init_pos = np.array([0, 0, -l_tarsus])
 
     femur_pos = r1.apply(fe_init_pos) + coxa_pos
-    tibia_pos = r1.apply(r2.apply(ti_init_pos)) + femur_pos            
+    tibia_pos = r1.apply(r2.apply(ti_init_pos)) + femur_pos
     tarsus_pos = r1.apply(r2.apply(r3.apply(ta_init_pos))) + tibia_pos
-    claw_pos = r1.apply(r2.apply(r3.apply(r4.apply(claw_init_pos)))) + tarsus_pos
+    claw_pos = r1.apply(
+        r2.apply(
+            r3.apply(
+                r4.apply(claw_init_pos)))) + tarsus_pos
 
-    fk_pos = np.array([coxa_pos,femur_pos,tibia_pos,tarsus_pos,claw_pos])
+    fk_pos = np.array([coxa_pos, femur_pos, tibia_pos, tarsus_pos, claw_pos])
 
     return fk_pos
+
 
 '''
 def calculate_best_roll_tr(angles,data_dict,begin=0,end=0):
@@ -276,7 +306,7 @@ def calculate_best_roll_tr(angles,data_dict,begin=0,end=0):
     diff_dict = {}
 
     if end == 0:
-        end = len(angles['LF_leg']['yawn'])    
+        end = len(angles['LF_leg']['yawn'])
 
     for frame in range(begin, end):
         print('\rFrame: '+str(frame),end='')
@@ -292,12 +322,12 @@ def calculate_best_roll_tr(angles,data_dict,begin=0,end=0):
             real_pos_tarsus = data_dict[name]['Tarsus']['raw_pos_aligned'][frame]
             #real_pos_claw = data_dict[name]['Claw']['raw_pos_aligned'][frame]
 
-            
+
             min_dist = 100000000
             best_roll = 0
             for i in range(-900, 900):
                 roll_tr = np.deg2rad(i/10)
-                    
+
                 pos_3d = calculate_forward_kinematics(name, frame, leg, data_dict,roll_tr=roll_tr)
 
                 dist = np.linalg.norm(pos_3d[4]-real_pos_tarsus)
@@ -308,7 +338,7 @@ def calculate_best_roll_tr(angles,data_dict,begin=0,end=0):
 
             diff_dict[name]['min_dist'].append(min_dist)
             diff_dict[name]['best_roll'].append(best_roll)
-            
-            
+
+
     return diff_dict
 '''

--- a/df3dPostProcessing/utils/utils_ball_info.py
+++ b/df3dPostProcessing/utils/utils_ball_info.py
@@ -2,71 +2,95 @@ import os
 import numpy as np
 import cv2 as cv
 
+
 def get_raw_images(video_path, num_imgs=np.inf, start=0):
-    raw_imgs=[]
+    raw_imgs = []
     cap = cv.VideoCapture(video_path)
-    
+
     if cap.isOpened() == False:
-        raise Exception('Video file cannot be read! Please check in_path to ensure it is correctly pointing to the video file')
-    cont=0
+        raise Exception(
+            'Video file cannot be read! Please check in_path to ensure it is correctly pointing to the video file')
+    cont = 0
     while(True):
         # Capture frame-by-frame
         ret, frame = cap.read()
         cont += 1
-        if ret == True and len(raw_imgs)<num_imgs:
+        if ret and len(raw_imgs) < num_imgs:
             if cont > start:
                 raw_imgs.append(frame)
         else:
             break
-    
+
     return cap, raw_imgs
+
 
 def get_foreground(imgs):
     #backSub = cv.createBackgroundSubtractorMOG2()
-    sum_img = np.zeros_like(imgs[0])[:,:,0]
-    kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE,(5,5))
+    sum_img = np.zeros_like(imgs[0])[:, :, 0]
+    kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE, (5, 5))
     for i, frame in enumerate(imgs):
         #fgMask = backSub.apply(frame)
         gray = cv.cvtColor(frame, cv.COLOR_BGR2GRAY)
         #open_mask = cv.morphologyEx(fgMask, cv.MORPH_OPEN, kernel)
-        #if i > 10:
-        sum_img = cv.bitwise_or(sum_img,gray)
+        # if i > 10:
+        sum_img = cv.bitwise_or(sum_img, gray)
     diff_img = sum_img - cv.cvtColor(imgs[0], cv.COLOR_BGR2GRAY)
     fg_img = cv.morphologyEx(diff_img, cv.MORPH_OPEN, kernel)
     #cv.imshow("mask", open_mask)
     #cv.imshow("fg_img", fg_img)
-    #cv.waitKey(0)
-            
+    # cv.waitKey(0)
+
     return fg_img, sum_img
+
 
 def fill_holes(im_th):
     im_floodfill = im_th.copy()
     h, w = im_th.shape[:2]
-    mask = np.zeros((h+2, w+2), np.uint8)
-    cv.floodFill(im_floodfill, mask, (int(w/2),int(h/2)), 255);
+    mask = np.zeros((h + 2, w + 2), np.uint8)
+    cv.floodFill(im_floodfill, mask, (int(w / 2), int(h / 2)), 255)
     im_floodfill_inv = cv.bitwise_not(im_floodfill)
     im_out = im_th | im_floodfill_inv
 
     return im_out
 
+
 def clean_img(img):
-    ret,th = cv.threshold(img,100,255,cv.THRESH_BINARY)
-    kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE,(31,31))
-    close_img = cv.morphologyEx(th, cv.MORPH_CLOSE, kernel)   
+    ret, th = cv.threshold(img, 100, 255, cv.THRESH_BINARY)
+    kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE, (31, 31))
+    close_img = cv.morphologyEx(th, cv.MORPH_CLOSE, kernel)
 
     #kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE,(225,225))
     #open_img = cv.morphologyEx(close_img, cv.MORPH_OPEN, kernel)
     #cv.imshow("close", close_img)
-    #cv.waitKey(0)
-    
+    # cv.waitKey(0)
+
     return close_img
 
-def get_ball_params(mask, raw_img, pos_fly, show_detection, minDist=100, param1=100, param2=10, minRad=250, maxRad=300, rad_correct=0):
+
+def get_ball_params(
+        mask,
+        raw_img,
+        pos_fly,
+        show_detection,
+        minDist=100,
+        param1=100,
+        param2=10,
+        minRad=250,
+        maxRad=300,
+        rad_correct=0):
     if show_detection:
         out_img = raw_img.copy()
     in_img = mask.copy()
     #in_img = cv.cvtColor(in_img, cv.COLOR_BGR2GRAY)
-    circles = cv.HoughCircles(in_img, cv.HOUGH_GRADIENT, 1, minDist, param1=param1, param2=param2, minRadius=minRad, maxRadius=maxRad)
+    circles = cv.HoughCircles(
+        in_img,
+        cv.HOUGH_GRADIENT,
+        1,
+        minDist,
+        param1=param1,
+        param2=param2,
+        minRadius=minRad,
+        maxRadius=maxRad)
     x_px = []
     y_px = []
     r_px = []
@@ -74,25 +98,29 @@ def get_ball_params(mask, raw_img, pos_fly, show_detection, minDist=100, param1=
         circles_round = np.round(circles[0, :]).astype("int")
         circles = circles[0, :]
         for (x, y, r) in circles:
-            #print(x,y,r)
+            # print(x,y,r)
             x_px.append(x)
             y_px.append(y)
-            r_px.append(r-rad_correct)
-            #print("r=",r)
+            r_px.append(r - rad_correct)
+            # print("r=",r)
         if show_detection:
             for (x_int, y_int, r_int) in circles_round:
-                cv.circle(out_img, (x_int, y_int), r_int-rad_correct, (0, 255, 0), 4)
-                cv.rectangle(out_img, (x_int - 5, y_int - 5), (x_int + 5, y_int + 5), (0, 128, 255), -1)
+                cv.circle(out_img, (x_int, y_int), r_int -
+                          rad_correct, (0, 255, 0), 4)
+                cv.rectangle(out_img, (x_int - 5, y_int - 5),
+                             (x_int + 5, y_int + 5), (0, 128, 255), -1)
     if show_detection:
         fly = np.round(pos_fly).astype("int")
-        cv.rectangle(out_img, (fly[0]-5, fly[1]-5), (fly[0]+5, fly[1]+5), (0, 128, 255), -1)
+        cv.rectangle(out_img, (fly[0] - 5, fly[1] - 5),
+                     (fly[0] + 5, fly[1] + 5), (0, 128, 255), -1)
         #cv.imshow("mask", mask)
         cv.imshow("output", out_img)
-        cv.imwrite("ball_detection.jpg",out_img)
+        cv.imwrite("ball_detection.jpg", out_img)
         cv.waitKey(0)
         cv.destroyAllWindows()
 
     return [np.mean(x_px), np.mean(y_px)], np.mean(r_px)
+
 
 def find_closest_to_roi(fly_mask, original):
     output = cv.connectedComponentsWithStats(fly_mask, 4, cv.CV_32S)
@@ -100,10 +128,10 @@ def find_closest_to_roi(fly_mask, original):
     sizes = stats[4]
     centroids = output[3]
     roi = cv.selectROI(original)
-    centroid_roi = [int(roi[0]+(roi[2]/2)),int(roi[1]+(roi[3]/2))]
-    min_dist=np.inf
+    centroid_roi = [int(roi[0] + (roi[2] / 2)), int(roi[1] + (roi[3] / 2))]
+    min_dist = np.inf
     for i, p in enumerate(centroids):
-        dist = np.linalg.norm(p-centroid_roi)
+        dist = np.linalg.norm(p - centroid_roi)
         if dist < min_dist:
             min_dist = dist
             ind = i
@@ -113,78 +141,90 @@ def find_closest_to_roi(fly_mask, original):
 
     return closest
 
+
 def get_fly_pos(mask, original):
     in_img = mask.copy()
     fly_mask = cv.bitwise_not(in_img)
 
     pos_fly = find_closest_to_roi(fly_mask, original)
-    
+
     return pos_fly
+
 
 def get_fly_pos_side(mask, original):
     in_img = mask.copy()
-    ret,th = cv.threshold(in_img,180,255,cv.THRESH_BINARY)
-    kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE,(15,15))
-    fly_mask = cv.erode(th,kernel,iterations = 1)#cv.morphologyEx(th, cv.MORPH_CLOSE, kernel) 
-    
+    ret, th = cv.threshold(in_img, 180, 255, cv.THRESH_BINARY)
+    kernel = cv.getStructuringElement(cv.MORPH_ELLIPSE, (15, 15))
+    # cv.morphologyEx(th, cv.MORPH_CLOSE, kernel)
+    fly_mask = cv.erode(th, kernel, iterations=1)
+
     pos_fly = find_closest_to_roi(fly_mask, original) - np.array([0, 10])
-    
+
     return pos_fly
-    
-def ball_size_and_pos(data_path, show_detection, front_camera=3, side_camera=7, px_size=18.4e-6):
+
+
+def ball_size_and_pos(
+        data_path,
+        show_detection,
+        front_camera=3,
+        side_camera=7,
+        px_size=18.4e-6):
 
     videos_folder = data_path[:data_path.find('/df3d')]
-    front_video_path = os.path.join(videos_folder,f'camera_{front_camera}.mp4')
-    side_video_path = os.path.join(videos_folder,f'camera_{side_camera}.mp4')
+    front_video_path = os.path.join(
+        videos_folder, f'camera_{front_camera}.mp4')
+    side_video_path = os.path.join(videos_folder, f'camera_{side_camera}.mp4')
 
     try:
-        _,front_imgs = get_raw_images(front_video_path, num_imgs=500, start=0)
+        _, front_imgs = get_raw_images(front_video_path, num_imgs=500, start=0)
         front = True
     except Exception as e:
         print('Front ' + str(e))
         front = False
 
     try:
-        _,side_imgs = get_raw_images(side_video_path, num_imgs=500)
+        _, side_imgs = get_raw_images(side_video_path, num_imgs=500)
         side = True
     except Exception as e:
         print('Side ' + str(e))
         side = False
-    
-    #print(videos_folder)
+
+    # print(videos_folder)
     rad_all = []
     if front:
         fg_front, _ = get_foreground(front_imgs)
         #fg_front = fill_holes(fg_front)
         mask_front = clean_img(fg_front)
         pos_fly_front = get_fly_pos(mask_front, front_imgs[0])
-        pos_ball_front, rad = get_ball_params(mask_front, front_imgs[0], pos_fly_front, show_detection)
+        pos_ball_front, rad = get_ball_params(
+            mask_front, front_imgs[0], pos_fly_front, show_detection)
         #print(pos_ball_front, pos_fly_front, rad)
         pos_front = pos_fly_front - pos_ball_front
         rad_all.append(rad)
     else:
-        pos_front = np.array([0,0])
-        
+        pos_front = np.array([0, 0])
+
     if side:
         fg_side, sum_side = get_foreground(side_imgs)
         mask_side = clean_img(fg_side)
         pos_fly_side = get_fly_pos_side(sum_side, side_imgs[0])
-        pos_ball_side, rad = get_ball_params(mask_side, side_imgs[0], pos_fly_side, show_detection)
+        pos_ball_side, rad = get_ball_params(
+            mask_side, side_imgs[0], pos_fly_side, show_detection)
         #print(pos_ball_side, pos_fly_side, rad)
         pos_side = pos_fly_side - pos_ball_side
         rad_all.append(rad)
     else:
-        pos_side = np.array([0,0])
-        
+        pos_side = np.array([0, 0])
+
     radius_px = np.mean(rad_all)
     x_pos = pos_side[0]
     y_pos = -pos_front[0]
-    z_pos = np.mean([pos_side[1],pos_front[1]]) if side else pos_front[1]
+    z_pos = np.mean([pos_side[1], pos_front[1]]) if side else pos_front[1]
     position_px = np.array([x_pos, y_pos, z_pos])
-    #print(pos_front)
-    #print(pos_side)
+    # print(pos_front)
+    # print(pos_side)
 
     radius = radius_px * px_size
     position = position_px * px_size + np.array([0.0, 0.0, 0.9e-3])
-    
+
     return radius, position

--- a/df3dPostProcessing/utils/utils_outliers.py
+++ b/df3dPostProcessing/utils/utils_outliers.py
@@ -4,6 +4,7 @@ import numpy as np
 import scipy.interpolate
 import deepfly.signal_util
 
+
 def find_outliers(camNet):
     """
     This function determines which 3D points were not correctly
@@ -29,29 +30,44 @@ def find_outliers(camNet):
                               10, 11, 12, 13,
                               19, 20, 21, 22,
                               24, 25, 26, 27,
-                              29, 30, 31, 32,],
+                              29, 30, 31, 32, ],
                              dtype=np.int)
     stop_indices = start_indices + 1
-    lengths = np.linalg.norm(camNet.points3d[:, start_indices, :] - camNet.points3d[:, stop_indices, :], axis=2)
+    lengths = np.linalg.norm(
+        camNet.points3d[:, start_indices, :] - camNet.points3d[:, stop_indices, :], axis=2)
     median_lengths = np.median(lengths, axis=0)
-    length_outliers = (lengths > median_lengths * 1.4) | (lengths < median_lengths * 0.4)
+    length_outliers = (
+        lengths > median_lengths *
+        1.4) | (
+        lengths < median_lengths *
+        0.4)
     outlier_mask = np.zeros(camNet.points3d.shape, dtype=np.bool)
     for i, mask_offset in enumerate([0, 5, 10, 19, 24, 29]):
-        claw_outliers = np.where(length_outliers[:, i * 4 + 3] & ~length_outliers[:, i * 4 + 2])[0]
-        tarsus_outliers = np.where(length_outliers[:, i * 4 + 3] & length_outliers[:, i * 4 + 2])[0]
-        tibia_outliers = np.where(length_outliers[:, i * 4 + 2] & length_outliers[:, i * 4 + 1])[0]
-        femur_outliers = np.where(length_outliers[:, i * 4 + 1] & length_outliers[:, i * 4 + 0])[0]
+        claw_outliers = np.where(
+            length_outliers[:, i * 4 + 3] & ~length_outliers[:, i * 4 + 2])[0]
+        tarsus_outliers = np.where(
+            length_outliers[:, i * 4 + 3] & length_outliers[:, i * 4 + 2])[0]
+        tibia_outliers = np.where(
+            length_outliers[:, i * 4 + 2] & length_outliers[:, i * 4 + 1])[0]
+        femur_outliers = np.where(
+            length_outliers[:, i * 4 + 1] & length_outliers[:, i * 4 + 0])[0]
         outlier_mask[femur_outliers, 1 + mask_offset] = True
         outlier_mask[tibia_outliers, 2 + mask_offset] = True
         outlier_mask[tarsus_outliers, 3 + mask_offset] = True
         outlier_mask[claw_outliers, 4 + mask_offset] = True
 
     outlier_mask = np.logical_or(outlier_mask, np.abs(camNet.points3d) > 5)
-    
+
     outlier_image_ids = np.where(outlier_mask)[0]
     outlier_joint_ids = np.where(outlier_mask)[1]
-    return {"image_ids": outlier_image_ids, "joint_ids": outlier_joint_ids, "median_lengths": median_lengths, "start_indices": start_indices, "stop_indices": stop_indices}
-    
+    return {
+        "image_ids": outlier_image_ids,
+        "joint_ids": outlier_joint_ids,
+        "median_lengths": median_lengths,
+        "start_indices": start_indices,
+        "stop_indices": stop_indices}
+
+
 def _triangluate_specific_cameras(camNet, cam_id_list, img_id, j_id):
     from deepfly.cv_util import triangulate_linear
     cam_list_iter = list()
@@ -61,15 +77,19 @@ def _triangluate_specific_cameras(camNet, cam_id_list, img_id, j_id):
         points2d_iter.append(cam[img_id, j_id, :])
     return triangulate_linear(cam_list_iter, points2d_iter)
 
+
 def interpolate_remaining_outliers(camNet, outliers):
     for joint_id in np.unique(outliers["joint_ids"]):
         joint_mask = outliers["joint_ids"] == joint_id
         frames = np.unique(outliers["image_ids"][joint_mask])
-        non_outlier_frames = np.array([i for i in range(camNet.points3d.shape[0]) if i not in frames])
+        non_outlier_frames = np.array(
+            [i for i in range(camNet.points3d.shape[0]) if i not in frames])
         non_outlier_values = camNet.points3d[non_outlier_frames, joint_id]
-        interp_func = scipy.interpolate.PchipInterpolator(non_outlier_frames, non_outlier_values, axis=0)
+        interp_func = scipy.interpolate.PchipInterpolator(
+            non_outlier_frames, non_outlier_values, axis=0)
         camNet.points3d[frames, joint_id] = interp_func(frames)
     return camNet
+
 
 def correct_outliers(camNet):
     outliers = find_outliers(camNet)
@@ -84,19 +104,24 @@ def correct_outliers(camNet):
         # Select cameras based on which side the joint is on
         all_cam_ids = [0, 1, 2] if joint_id < 19 else [4, 5, 6]
         for subset_cam_ids in itertools.combinations(all_cam_ids, 2):
-            points3d_using_2_cams = _triangluate_specific_cameras(camNet, subset_cam_ids, img_id, joint_id)
+            points3d_using_2_cams = _triangluate_specific_cameras(
+                camNet, subset_cam_ids, img_id, joint_id)
 
             new_diff = 0
             median_index = np.where(stop_indices == joint_id)[0]
             if len(median_index) > 0:
-                new_diff += np.linalg.norm(points3d_using_2_cams - camNet.points3d[img_id, joint_id - 1]) - median_lengths[median_index]
+                new_diff += np.linalg.norm(points3d_using_2_cams - \
+                                           camNet.points3d[img_id, joint_id - 1]) - median_lengths[median_index]
             median_index = np.where(start_indices == joint_id)[0]
             if len(median_index) > 0:
-                new_diff += np.linalg.norm(points3d_using_2_cams - camNet.points3d[img_id, joint_id + 1]) - median_lengths[median_index]
+                new_diff += np.linalg.norm(points3d_using_2_cams - \
+                                           camNet.points3d[img_id, joint_id + 1]) - median_lengths[median_index]
             segment_length_diff.append(new_diff)
 
-            reprojection_error_function = lambda cam_id: camNet.cam_list[cam_id].project(points3d_using_2_cams) - camNet.cam_list[cam_id].points2d[img_id, joint_id]
-            reprojection_error = np.mean([reprojection_error_function(cam_id) for cam_id in subset_cam_ids])
+            def reprojection_error_function(cam_id): return camNet.cam_list[cam_id].project(
+                points3d_using_2_cams) - camNet.cam_list[cam_id].points2d[img_id, joint_id]
+            reprojection_error = np.mean(
+                [reprojection_error_function(cam_id) for cam_id in subset_cam_ids])
             reprojection_errors.append(reprojection_error)
             points_using_2_cams.append(points3d_using_2_cams)
 
@@ -106,18 +131,26 @@ def correct_outliers(camNet):
         new_diff = 0
         median_index = np.where(stop_indices == joint_id)[0]
         if len(median_index) > 0:
-            old_diff += np.linalg.norm(camNet.points3d[img_id, joint_id] - camNet.points3d[img_id, joint_id - 1]) - median_lengths[median_index]
-            new_diff += np.linalg.norm(points_using_2_cams[best_cam_tuple_index] - camNet.points3d[img_id, joint_id - 1]) - median_lengths[median_index]
+            old_diff += np.linalg.norm(camNet.points3d[img_id,
+                                                       joint_id] - camNet.points3d[img_id,
+                                                                                   joint_id - 1]) - median_lengths[median_index]
+            new_diff += np.linalg.norm(points_using_2_cams[best_cam_tuple_index] -
+                                       camNet.points3d[img_id, joint_id - 1]) - median_lengths[median_index]
         median_index = np.where(start_indices == joint_id)[0]
         if len(median_index) > 0:
-            old_diff += np.linalg.norm(camNet.points3d[img_id, joint_id] - camNet.points3d[img_id, joint_id + 1]) - median_lengths[median_index]
-            new_diff += np.linalg.norm(points_using_2_cams[best_cam_tuple_index] - camNet.points3d[img_id, joint_id + 1]) - median_lengths[median_index]
+            old_diff += np.linalg.norm(camNet.points3d[img_id,
+                                                       joint_id] - camNet.points3d[img_id,
+                                                                                   joint_id + 1]) - median_lengths[median_index]
+            new_diff += np.linalg.norm(points_using_2_cams[best_cam_tuple_index] -
+                                       camNet.points3d[img_id, joint_id + 1]) - median_lengths[median_index]
 
         if new_diff < old_diff:
-            camNet.points3d[img_id, joint_id] = points_using_2_cams[best_cam_tuple_index]
-    
+            camNet.points3d[img_id,
+                            joint_id] = points_using_2_cams[best_cam_tuple_index]
+
     outliers = find_outliers(camNet)
     camNet = interpolate_remaining_outliers(camNet, outliers)
 
-    camNet.points3d = deepfly.signal_util.filter_batch(camNet.points3d, freq=100)
+    camNet.points3d = deepfly.signal_util.filter_batch(
+        camNet.points3d, freq=100)
     return camNet

--- a/df3dPostProcessing/utils/utils_outliers.py
+++ b/df3dPostProcessing/utils/utils_outliers.py
@@ -1,0 +1,123 @@
+import itertools
+
+import numpy as np
+import scipy.interpolate
+import deepfly.signal_util
+
+def find_outliers(camNet):
+    """
+    This function determines which 3D points were not correctly
+    estimated by df3d.
+    It uses the segment length and an absolute threshold to
+    determine if a joint position is an outlier or not.
+
+    Parameters:
+    -----------
+    camNet : camNet object from df3d
+
+    Returns:
+    --------
+    outliers: dict
+        A dictionary that holds the `image_ids` (frame numbers)
+        `joint_ids` of each outlier.
+        Additionally, it holds the `median_lengths` of each leg segment,
+        the `start_indices` and `stop_indices` in joint number used to
+        compute the segments.
+    """
+    start_indices = np.array([0, 1, 2, 3,
+                              5, 6, 7, 8,
+                              10, 11, 12, 13,
+                              19, 20, 21, 22,
+                              24, 25, 26, 27,
+                              29, 30, 31, 32,],
+                             dtype=np.int)
+    stop_indices = start_indices + 1
+    lengths = np.linalg.norm(camNet.points3d[:, start_indices, :] - camNet.points3d[:, stop_indices, :], axis=2)
+    median_lengths = np.median(lengths, axis=0)
+    length_outliers = (lengths > median_lengths * 1.4) | (lengths < median_lengths * 0.4)
+    outlier_mask = np.zeros(camNet.points3d.shape, dtype=np.bool)
+    for i, mask_offset in enumerate([0, 5, 10, 19, 24, 29]):
+        claw_outliers = np.where(length_outliers[:, i * 4 + 3] & ~length_outliers[:, i * 4 + 2])[0]
+        tarsus_outliers = np.where(length_outliers[:, i * 4 + 3] & length_outliers[:, i * 4 + 2])[0]
+        tibia_outliers = np.where(length_outliers[:, i * 4 + 2] & length_outliers[:, i * 4 + 1])[0]
+        femur_outliers = np.where(length_outliers[:, i * 4 + 1] & length_outliers[:, i * 4 + 0])[0]
+        outlier_mask[femur_outliers, 1 + mask_offset] = True
+        outlier_mask[tibia_outliers, 2 + mask_offset] = True
+        outlier_mask[tarsus_outliers, 3 + mask_offset] = True
+        outlier_mask[claw_outliers, 4 + mask_offset] = True
+
+    outlier_mask = np.logical_or(outlier_mask, np.abs(camNet.points3d) > 5)
+    
+    outlier_image_ids = np.where(outlier_mask)[0]
+    outlier_joint_ids = np.where(outlier_mask)[1]
+    return {"image_ids": outlier_image_ids, "joint_ids": outlier_joint_ids, "median_lengths": median_lengths, "start_indices": start_indices, "stop_indices": stop_indices}
+    
+def _triangluate_specific_cameras(camNet, cam_id_list, img_id, j_id):
+    from deepfly.cv_util import triangulate_linear
+    cam_list_iter = list()
+    points2d_iter = list()
+    for cam in [camNet.cam_list[cam_idx] for cam_idx in cam_id_list]:
+        cam_list_iter.append(cam)
+        points2d_iter.append(cam[img_id, j_id, :])
+    return triangulate_linear(cam_list_iter, points2d_iter)
+
+def interpolate_remaining_outliers(camNet, outliers):
+    for joint_id in np.unique(outliers["joint_ids"]):
+        joint_mask = outliers["joint_ids"] == joint_id
+        frames = np.unique(outliers["image_ids"][joint_mask])
+        non_outlier_frames = np.array([i for i in range(camNet.points3d.shape[0]) if i not in frames])
+        non_outlier_values = camNet.points3d[non_outlier_frames, joint_id]
+        interp_func = scipy.interpolate.PchipInterpolator(non_outlier_frames, non_outlier_values, axis=0)
+        camNet.points3d[frames, joint_id] = interp_func(frames)
+    return camNet
+
+def correct_outliers(camNet):
+    outliers = find_outliers(camNet)
+    median_lengths = outliers["median_lengths"]
+    start_indices = outliers["start_indices"]
+    stop_indices = outliers["stop_indices"]
+
+    for img_id, joint_id in zip(outliers["image_ids"], outliers["joint_ids"]):
+        reprojection_errors = list()
+        segment_length_diff = list()
+        points_using_2_cams = list()
+        # Select cameras based on which side the joint is on
+        all_cam_ids = [0, 1, 2] if joint_id < 19 else [4, 5, 6]
+        for subset_cam_ids in itertools.combinations(all_cam_ids, 2):
+            points3d_using_2_cams = _triangluate_specific_cameras(camNet, subset_cam_ids, img_id, joint_id)
+
+            new_diff = 0
+            median_index = np.where(stop_indices == joint_id)[0]
+            if len(median_index) > 0:
+                new_diff += np.linalg.norm(points3d_using_2_cams - camNet.points3d[img_id, joint_id - 1]) - median_lengths[median_index]
+            median_index = np.where(start_indices == joint_id)[0]
+            if len(median_index) > 0:
+                new_diff += np.linalg.norm(points3d_using_2_cams - camNet.points3d[img_id, joint_id + 1]) - median_lengths[median_index]
+            segment_length_diff.append(new_diff)
+
+            reprojection_error_function = lambda cam_id: camNet.cam_list[cam_id].project(points3d_using_2_cams) - camNet.cam_list[cam_id].points2d[img_id, joint_id]
+            reprojection_error = np.mean([reprojection_error_function(cam_id) for cam_id in subset_cam_ids])
+            reprojection_errors.append(reprojection_error)
+            points_using_2_cams.append(points3d_using_2_cams)
+
+        best_cam_tuple_index = np.argmin(segment_length_diff)
+
+        old_diff = 0
+        new_diff = 0
+        median_index = np.where(stop_indices == joint_id)[0]
+        if len(median_index) > 0:
+            old_diff += np.linalg.norm(camNet.points3d[img_id, joint_id] - camNet.points3d[img_id, joint_id - 1]) - median_lengths[median_index]
+            new_diff += np.linalg.norm(points_using_2_cams[best_cam_tuple_index] - camNet.points3d[img_id, joint_id - 1]) - median_lengths[median_index]
+        median_index = np.where(start_indices == joint_id)[0]
+        if len(median_index) > 0:
+            old_diff += np.linalg.norm(camNet.points3d[img_id, joint_id] - camNet.points3d[img_id, joint_id + 1]) - median_lengths[median_index]
+            new_diff += np.linalg.norm(points_using_2_cams[best_cam_tuple_index] - camNet.points3d[img_id, joint_id + 1]) - median_lengths[median_index]
+
+        if new_diff < old_diff:
+            camNet.points3d[img_id, joint_id] = points_using_2_cams[best_cam_tuple_index]
+    
+    outliers = find_outliers(camNet)
+    camNet = interpolate_remaining_outliers(camNet, outliers)
+
+    camNet.points3d = deepfly.signal_util.filter_batch(camNet.points3d, freq=100)
+    return camNet

--- a/df3dPostProcessing/utils/utils_plots.py
+++ b/df3dPostProcessing/utils/utils_plots.py
@@ -11,7 +11,7 @@ import pandas as pd
 from scipy import stats
 from statsmodels.stats import weightstats as stests
 from .utils_angles import calculate_forward_kinematics
-from ikpy.chain import Chain 
+from ikpy.chain import Chain
 from ikpy.link import OriginLink, URDFLink
 from matplotlib.legend_handler import HandlerTuple
 from scipy import ndimage
@@ -25,41 +25,60 @@ from pathlib import Path
 import pkgutil
 import scikit_posthocs as sp
 
-def plot_angles(angles,key,degrees=True):
-    leg=angles[key+'_leg']
-   
-    fig_top = plt.figure()  
+
+def plot_angles(angles, key, degrees=True):
+    leg = angles[key + '_leg']
+
+    fig_top = plt.figure()
     ax_2d = plt.axes()
     for name, angle in leg.items():
         if degrees:
-            angle = np.array(angle)*180/np.pi
+            angle = np.array(angle) * 180 / np.pi
         ax_2d.plot(angle, label=name)
 
-    title = key+' leg angles'
+    title = key + ' leg angles'
     ax_2d.legend()
     plt.title(title)
     ax_2d.set_xlabel('time')
     ax_2d.set_ylabel('deg')
-    ax_2d.set_ylim(-230,200)
+    ax_2d.set_ylim(-230, 200)
     ax_2d.grid(True)
-    
+
     plt.show()
 
-def plot_angles_torques_grf(leg_key, angles={}, sim_data='walking', exp_dir='experiment', plot_angles=True, plot_torques=True, plot_grf=True, plot_collisions=True, collisions_across=True, begin=0.0, end=0.0, save_imgs=False, dir_name='dataPlots',torqueScalingFactor=1, grfScalingFactor=1, tot_time=9.0, time_step=0.001):    
 
-    data2plot={}
+def plot_angles_torques_grf(
+        leg_key,
+        angles={},
+        sim_data='walking',
+        exp_dir='experiment',
+        plot_angles=True,
+        plot_torques=True,
+        plot_grf=True,
+        plot_collisions=True,
+        collisions_across=True,
+        begin=0.0,
+        end=0.0,
+        save_imgs=False,
+        dir_name='dataPlots',
+        torqueScalingFactor=1,
+        grfScalingFactor=1,
+        tot_time=9.0,
+        time_step=0.001):
 
-    equivalence = {'ThC yaw':['yaw','Coxa_yaw'],
-                   'ThC pitch':['pitch','Coxa'],
-                   'ThC roll':['roll','Coxa_roll'],
-                   'CTr pitch':['th_fe','Femur'],
-                   'CTr roll':['roll_tr','Femur_roll'],
-                   'FTi pitch':['th_ti','Tibia'],
-                   'TiTa pitch':['th_ta','Tarsus1']}
+    data2plot = {}
+
+    equivalence = {'ThC yaw': ['yaw', 'Coxa_yaw'],
+                   'ThC pitch': ['pitch', 'Coxa'],
+                   'ThC roll': ['roll', 'Coxa_roll'],
+                   'CTr pitch': ['th_fe', 'Femur'],
+                   'CTr roll': ['roll_tr', 'Femur_roll'],
+                   'FTi pitch': ['th_ti', 'Tibia'],
+                   'TiTa pitch': ['th_ta', 'Tarsus1']}
 
     pkg_path = Path(pkgutil.get_loader("NeuroMechFly").get_filename())
-    sim_res_folder = os.path.join(pkg_path.parents[1],'scripts/KM/results')
-    
+    sim_res_folder = os.path.join(pkg_path.parents[1], 'scripts/KM/results')
+
     #sim_res_folder = '/home/nely/SimFly/kinematic_matching/results/'
     torques_data = sim_res_folder + '/torquesSC_data_ball_' + sim_data + '.pkl'
     if sim_data == 'walking':
@@ -70,13 +89,13 @@ def plot_angles_torques_grf(leg_key, angles={}, sim_data='walking', exp_dir='exp
     if end == 0:
         end = tot_time
 
-    steps = 1/time_step
-    start = int(begin*steps)
-    stop = int(end*steps)
+    steps = 1 / time_step
+    start = int(begin * steps)
+    stop = int(end * steps)
 
     if plot_angles:
-        angles_raw = angles[leg_key+'_leg']
-        data2plot['angles']={}
+        angles_raw = angles[leg_key + '_leg']
+        data2plot['angles'] = {}
         for label, match_labels in equivalence.items():
             for key in angles_raw.keys():
                 if key in match_labels:
@@ -86,7 +105,7 @@ def plot_angles_torques_grf(leg_key, angles={}, sim_data='walking', exp_dir='exp
             torques_all = pickle.load(fp)
         torques_raw = {}
         for joint, torque in torques_all.items():
-            if leg_key in joint and not 'Haltere' in joint:
+            if leg_key in joint and 'Haltere' not in joint:
                 if 'Tarsus' not in joint or 'Tarsus1' in joint:
                     joint_data = joint.split('joint_')
                     label = joint_data[1][2:]
@@ -100,13 +119,12 @@ def plot_angles_torques_grf(leg_key, angles={}, sim_data='walking', exp_dir='exp
         if plot_grf:
             with open(grf_data, 'rb') as fp:
                 data2plot['grf'] = pickle.load(fp)
-            grf = []            
+            grf = []
             for leg, force in data2plot['grf'].items():
                 if leg[:2] == leg_key:
                     grf.append(force.transpose()[0])
-            sum_force = np.sum(np.array(grf), axis = 0)
-            leg_force = np.delete(sum_force,0)
-
+            sum_force = np.sum(np.array(grf), axis=0)
+            leg_force = np.delete(sum_force, 0)
 
             #w_size = int(math.ceil(len(leg_force)/9*0.025))
             #filtered_force = ndimage.median_filter(leg_force,size=w_size)
@@ -114,204 +132,226 @@ def plot_angles_torques_grf(leg_key, angles={}, sim_data='walking', exp_dir='exp
         if plot_collisions:
             with open(collisions_data, 'rb') as fp:
                 data2plot['collisions'] = pickle.load(fp)
-            collisions=[]
+            collisions = []
             contra_coll = []
             ant_coll = []
             for segment, coll in data2plot['collisions'].items():
                 for key, forces in coll.items():
                     side = leg_key[0]
                     if side == 'L':
-                        contra_lateral_leg = leg_key.replace(side,'R')
+                        contra_lateral_leg = leg_key.replace(side, 'R')
                     else:
-                        contra_lateral_leg = leg_key.replace(side,'L')
-                    antenna = side+'Antenna'
+                        contra_lateral_leg = leg_key.replace(side, 'L')
+                    antenna = side + 'Antenna'
                     if segment[:2] == leg_key:
-                        collisions.append([np.linalg.norm(force) for force in forces])
+                        collisions.append([np.linalg.norm(force)
+                                          for force in forces])
                     elif segment[:2] == contra_lateral_leg:
-                        contra_coll.append([np.linalg.norm(force) for force in forces])
+                        contra_coll.append([np.linalg.norm(force)
+                                           for force in forces])
                     elif segment == antenna:
-                        ant_coll.append([np.linalg.norm(force) for force in forces])
-            sum_leg = np.sum(np.array(collisions), axis = 0)
-            sum_contra_leg = np.sum(np.array(contra_coll), axis = 0)
-            sum_ant = np.sum(np.array(ant_coll), axis = 0)
-            leg_force = np.delete(sum_leg,0)
-            contra_force = np.delete(sum_contra_leg,0)
-            antenna_force = np.delete(sum_ant,0)
+                        ant_coll.append([np.linalg.norm(force)
+                                        for force in forces])
+            sum_leg = np.sum(np.array(collisions), axis=0)
+            sum_contra_leg = np.sum(np.array(contra_coll), axis=0)
+            sum_ant = np.sum(np.array(ant_coll), axis=0)
+            leg_force = np.delete(sum_leg, 0)
+            contra_force = np.delete(sum_contra_leg, 0)
+            antenna_force = np.delete(sum_ant, 0)
             leg_vs_leg = []
             leg_vs_ant = []
             for i, f in enumerate(leg_force):
-                if f > 0 and antenna_force[i]>0:
+                if f > 0 and antenna_force[i] > 0:
                     leg_vs_ant.append(f)
                     leg_vs_leg.append(0)
-                elif f > 0 and contra_force[i]>0:
+                elif f > 0 and contra_force[i] > 0:
                     leg_vs_ant.append(0)
-                    leg_vs_leg.append(f)                    
-                elif f==0:
+                    leg_vs_leg.append(f)
+                elif f == 0:
                     leg_vs_leg.append(0)
                     leg_vs_ant.append(0)
-            
+
     if collisions_across:
-        if not plot_grf and sim_data=='walking':
+        if not plot_grf and sim_data == 'walking':
             with open(grf_data, 'rb') as fp:
                 grf_val = pickle.load(fp)
-            grf = []            
+            grf = []
             for leg, force in grf_val.items():
                 if leg[:2] == leg_key:
                     grf.append(force.transpose()[0])
-            sum_force = np.sum(np.array(grf), axis = 0)
-            leg_force = np.delete(sum_force,0)
-        if not plot_collisions and sim_data =='grooming':
+            sum_force = np.sum(np.array(grf), axis=0)
+            leg_force = np.delete(sum_force, 0)
+        if not plot_collisions and sim_data == 'grooming':
             with open(collisions_data, 'rb') as fp:
                 data2plot['collisions'] = pickle.load(fp)
-            collisions=[]
+            collisions = []
             contra_coll = []
             ant_coll = []
             for segment, coll in data2plot['collisions'].items():
                 for key, forces in coll.items():
                     side = leg_key[0]
                     if side == 'L':
-                        contra_lateral_leg = leg_key.replace(side,'R')
+                        contra_lateral_leg = leg_key.replace(side, 'R')
                     else:
-                        contra_lateral_leg = leg_key.replace(side,'L')
-                    antenna = side+'Antenna'
+                        contra_lateral_leg = leg_key.replace(side, 'L')
+                    antenna = side + 'Antenna'
                     if segment[:2] == leg_key:
-                        collisions.append([np.linalg.norm(force) for force in forces])
+                        collisions.append([np.linalg.norm(force)
+                                          for force in forces])
                     elif segment[:2] == contra_lateral_leg:
-                        contra_coll.append([np.linalg.norm(force) for force in forces])
+                        contra_coll.append([np.linalg.norm(force)
+                                           for force in forces])
                     elif segment == antenna:
-                        ant_coll.append([np.linalg.norm(force) for force in forces])
-            sum_leg = np.sum(np.array(collisions), axis = 0)
-            sum_contra_leg = np.sum(np.array(contra_coll), axis = 0)
-            sum_ant = np.sum(np.array(ant_coll), axis = 0)
-            leg_force = np.delete(sum_leg,0)
-            contra_force = np.delete(sum_contra_leg,0)
-            antenna_force = np.delete(sum_ant,0)
+                        ant_coll.append([np.linalg.norm(force)
+                                        for force in forces])
+            sum_leg = np.sum(np.array(collisions), axis=0)
+            sum_contra_leg = np.sum(np.array(contra_coll), axis=0)
+            sum_ant = np.sum(np.array(ant_coll), axis=0)
+            leg_force = np.delete(sum_leg, 0)
+            contra_force = np.delete(sum_contra_leg, 0)
+            antenna_force = np.delete(sum_ant, 0)
             leg_vs_leg = []
             leg_vs_ant = []
             for i, f in enumerate(leg_force):
-                if f != 0 and antenna_force[i]>0:
+                if f != 0 and antenna_force[i] > 0:
                     leg_vs_ant.append(f)
                     leg_vs_leg.append(0)
-                elif f != 0 and contra_force[i]>0:
+                elif f != 0 and contra_force[i] > 0:
                     leg_vs_ant.append(0)
-                    leg_vs_leg.append(f)                    
-                elif f==0:
+                    leg_vs_leg.append(f)
+                elif f == 0:
                     leg_vs_leg.append(0)
                     leg_vs_ant.append(0)
-                    
-        stance_ind = np.where(leg_force>0)[0]
-        if stance_ind.size!=0:
+
+        stance_ind = np.where(leg_force > 0)[0]
+        if stance_ind.size != 0:
             stance_diff = np.diff(stance_ind)
-            stance_lim = np.where(stance_diff>1)[0]
-            stance=[stance_ind[0]-1]
+            stance_lim = np.where(stance_diff > 1)[0]
+            stance = [stance_ind[0] - 1]
             for ind in stance_lim:
-                stance.append(stance_ind[ind]+1)
-                stance.append(stance_ind[ind+1]-1)
+                stance.append(stance_ind[ind] + 1)
+                stance.append(stance_ind[ind + 1] - 1)
             stance.append(stance_ind[-1])
             start_gait_list = np.where(np.array(stance) >= start)[0]
-            if len(start_gait_list)>0:
+            if len(start_gait_list) > 0:
                 start_gait = start_gait_list[0]
             else:
-                start_gait = start            
+                start_gait = start
             stop_gait_list = np.where(np.array(stance) <= stop)[0]
-            if len(stop_gait_list)>0:
-                stop_gait = stop_gait_list[-1]+1
+            if len(stop_gait_list) > 0:
+                stop_gait = stop_gait_list[-1] + 1
             else:
                 stop_gait = start_gait
             stance_plot = stance[start_gait:stop_gait]
-            if start_gait%2 != 0:
-                stance_plot.insert(0,start)
-            if len(stance_plot)%2 != 0:
+            if start_gait % 2 != 0:
+                stance_plot.insert(0, start)
+            if len(stance_plot) % 2 != 0:
                 stance_plot.append(stop)
-    
-    fig, axs = plt.subplots(len(data2plot.keys()), sharex=True)
-    fig.suptitle(dir_name+' '+leg_key+ ' leg')
 
-    torque_min=np.inf
-    torque_max=0
-    grf_min=np.inf
-    grf_max=0
+    fig, axs = plt.subplots(len(data2plot.keys()), sharex=True)
+    fig.suptitle(dir_name + ' ' + leg_key + ' leg')
+
+    torque_min = np.inf
+    torque_max = 0
+    grf_min = np.inf
+    grf_max = 0
 
     for i, (plot, data) in enumerate(data2plot.items()):
         if plot == 'angles':
             for name, angle_rad in data.items():
-                time = np.arange(0,len(angle_rad),1)/steps
-                angle = np.array(angle_rad)*180/np.pi
+                time = np.arange(0, len(angle_rad), 1) / steps
+                angle = np.array(angle_rad) * 180 / np.pi
                 axs[i].plot(time[start:stop], angle[start:stop], label=name)
             axs[i].set_ylabel('Joint angle (deg)')
 
         if plot == 'torques':
             for joint, torque in data.items():
-                torque_adj = np.delete(torque,0)
-                time = np.arange(0,len(torque_adj),1)/steps
-                axs[i].plot(time[start:stop], torque_adj[start:stop]*torqueScalingFactor,label=joint)
-            
-                t_min = np.min(torque_adj[start:stop]*torqueScalingFactor)
-                t_max = np.max(torque_adj[start:stop]*torqueScalingFactor)
-            
+                torque_adj = np.delete(torque, 0)
+                time = np.arange(0, len(torque_adj), 1) / steps
+                axs[i].plot(time[start:stop], torque_adj[start:stop]
+                            * torqueScalingFactor, label=joint)
+
+                t_min = np.min(torque_adj[start:stop] * torqueScalingFactor)
+                t_max = np.max(torque_adj[start:stop] * torqueScalingFactor)
+
                 if t_min < torque_min:
                     torque_min = t_min
-                
+
                 if t_max > torque_max:
                     torque_max = t_max
 
             axs[i].set_ylabel('Joint torque ' + r'$(\mu Nmm)$')
-            axs[i].set_ylim(1.2*torque_min, 1.1*torque_max)
-           
+            axs[i].set_ylim(1.2 * torque_min, 1.1 * torque_max)
 
         if plot == 'grf':
-            time = np.arange(0,len(leg_force),1)/steps
-            axs[i].plot(time[start:stop],leg_force[start:stop]*grfScalingFactor,color='black')
+            time = np.arange(0, len(leg_force), 1) / steps
+            axs[i].plot(time[start:stop], leg_force[start:stop]
+                        * grfScalingFactor, color='black')
             axs[i].set_ylabel('Ball reaction force' + r'$(\mu N)$')
-            f_min = np.min(leg_force[start:stop]*grfScalingFactor)
-            f_max = np.max(leg_force[start:stop]*grfScalingFactor)
-            
+            f_min = np.min(leg_force[start:stop] * grfScalingFactor)
+            f_max = np.max(leg_force[start:stop] * grfScalingFactor)
+
             if f_min < grf_min:
                 grf_min = f_min
-                
+
             if f_max > grf_max:
                 grf_max = f_max
-                
-            axs[i].set_ylim(-0.003, 1.1*grf_max)
+
+            axs[i].set_ylim(-0.003, 1.1 * grf_max)
 
         if plot == 'collisions':
-            time = np.arange(0,len(leg_force),1)/steps
-            axs[i].plot(time[start:stop],np.array(leg_vs_leg[start:stop])*grfScalingFactor,color='black',label=['Leg vs leg force'])
-            axs[i].plot(time[start:stop],np.array(leg_vs_ant[start:stop])*grfScalingFactor,color='dimgray',label=['Leg vs antenna force'])
+            time = np.arange(0, len(leg_force), 1) / steps
+            axs[i].plot(time[start:stop],
+                        np.array(leg_vs_leg[start:stop]) * grfScalingFactor,
+                        color='black',
+                        label=['Leg vs leg force'])
+            axs[i].plot(time[start:stop],
+                        np.array(leg_vs_ant[start:stop]) * grfScalingFactor,
+                        color='dimgray',
+                        label=['Leg vs antenna force'])
             axs[i].set_ylabel('Contact forces (mN)')
-            
+
         axs[i].grid(True)
         if plot != 'grf' and i == 0:
             plot_handles, plot_labels = axs[i].get_legend_handles_labels()
-            if collisions_across and sim_data=='walking':
+            if collisions_across and sim_data == 'walking':
                 gray_patch = mpatches.Patch(color='gray')
                 all_handles = plot_handles + [gray_patch]
-                all_labels = plot_labels+ ['Stance']
-            elif collisions_across and sim_data=='grooming':
+                all_labels = plot_labels + ['Stance']
+            elif collisions_across and sim_data == 'grooming':
                 gray_patch = mpatches.Patch(color='dimgray')
                 darkgray_patch = mpatches.Patch(color='darkgray')
                 all_handles = plot_handles + [gray_patch] + [darkgray_patch]
-                all_labels = plot_labels + ['Foreleg grooming'] + ['Antennal grooming']
+                all_labels = plot_labels + \
+                    ['Foreleg grooming'] + ['Antennal grooming']
             else:
                 all_handles = plot_handles
                 all_labels = plot_labels
-            axs[i].legend(all_handles, all_labels,loc= 'upper right',bbox_to_anchor=(1.135, 1))
+            axs[i].legend(
+                all_handles,
+                all_labels,
+                loc='upper right',
+                bbox_to_anchor=(
+                    1.135,
+                    1))
 
         if collisions_across:
-            for ind in range(0,len(stance_plot),2):
-                if sim_data=='walking':
+            for ind in range(0, len(stance_plot), 2):
+                if sim_data == 'walking':
                     c = 'gray'
-                if sim_data=='grooming':
-                    if np.sum(leg_vs_leg[stance_plot[ind]:stance_plot[ind+1]])>0:
+                if sim_data == 'grooming':
+                    if np.sum(leg_vs_leg[stance_plot[ind]                              :stance_plot[ind + 1]]) > 0:
                         c = 'dimgray'
-                    elif np.sum(leg_vs_ant[stance_plot[ind]:stance_plot[ind+1]])>0:
+                    elif np.sum(leg_vs_ant[stance_plot[ind]:stance_plot[ind + 1]]) > 0:
                         c = 'darkgray'
-                axs[i].fill_between(time[stance_plot[ind]:stance_plot[ind+1]], 0, 1, facecolor=c, alpha=0.5, transform=axs[i].get_xaxis_transform())
-                
+                axs[i].fill_between(time[stance_plot[ind]:stance_plot[ind + 1]], 0,
+                                    1, facecolor=c, alpha=0.5, transform=axs[i].get_xaxis_transform())
+
         #axs[i].fill_between(time[start:stop], 0, 1, where=leg_force[start:stop] > 0, facecolor='gray', alpha=0.5, transform=axs[i].get_xaxis_transform(),step='pre')
-        
-    axs[len(axs)-1].set_xlabel('Time (s)')
+
+    axs[len(axs) - 1].set_xlabel('Time (s)')
     plt.show()
+
 
 '''
 def plot_gait_diagram(begin=0,end=0):
@@ -324,16 +364,16 @@ def plot_gait_diagram(begin=0,end=0):
 
     start = int(begin*100)
     stop = int(end*100)
-    
+
     with open(grf_data, 'rb') as fp:
         data = pickle.load(fp)
-    grf = {'LF':[],'LM':[],'LH':[],'RF':[],'RM':[],'RH':[]}            
+    grf = {'LF':[],'LM':[],'LH':[],'RF':[],'RM':[],'RH':[]}
     for leg, force in data.items():
         grf[leg[:2]].append(force)
 
-    
+
     title_plot = 'Gait diagram'
-    
+
     fig, axs = plt.subplots(len(grf.keys()), sharex=True,gridspec_kw={'hspace': 0})
     fig.suptitle(title_plot)
 
@@ -349,7 +389,7 @@ def plot_gait_diagram(begin=0,end=0):
             stance.append(stance_ind[ind]+1)
             stance.append(stance_ind[ind+1]-1)
         stance.append(stance_ind[-1])
-        
+
         start_gait = np.where(np.array(stance) >= start)[0][0]
         stop_gait = np.where(np.array(stance) <= stop)[0][-1]+1
         stance_plot = stance[start_gait:stop_gait]
@@ -370,40 +410,71 @@ def plot_gait_diagram(begin=0,end=0):
     plt.show()
 '''
 
-def plot_collisions_diagram(sim_data, begin=0, end=0, opt_res=False, generation='', exp='',tot_time=9.0, time_step=0.001):
-    data={}
+
+def plot_collisions_diagram(
+        sim_data,
+        begin=0,
+        end=0,
+        opt_res=False,
+        generation='',
+        exp='',
+        tot_time=9.0,
+        time_step=0.001):
+    data = {}
     pkg_path = Path(pkgutil.get_loader("NeuroMechFly").get_filename())
-    sim_res_folder = os.path.join(pkg_path.parents[1],'scripts/KM/results')
+    sim_res_folder = os.path.join(pkg_path.parents[1], 'scripts/KM/results')
 
     if sim_data == 'walking':
         if not opt_res:
             collisions_data = sim_res_folder + '/grfSC_data_ball_walking.pkl'
         else:
-            sim_res_folder = os.path.join(pkg_path.parents[1],'scripts/Optimization/Output_data/grf',exp)
-            collisions_data = sim_res_folder +'/grf_optimization_gen_'+generation+'.pkl'
+            sim_res_folder = os.path.join(
+                pkg_path.parents[1], 'scripts/Optimization/Output_data/grf', exp)
+            collisions_data = sim_res_folder + '/grf_optimization_gen_' + generation + '.pkl'
     elif sim_data == 'grooming':
         collisions_data = sim_res_folder + '/selfCollisions_data_ball_grooming.pkl'
 
     if end == 0:
-        end = tot_time 
+        end = tot_time
 
-    steps = 1/time_step
-    start = int(begin*steps)
-    stop = int(end*steps)
-    
+    steps = 1 / time_step
+    start = int(begin * steps)
+    stop = int(end * steps)
+
     with open(collisions_data, 'rb') as fp:
-        data = pickle.load(fp)    
+        data = pickle.load(fp)
 
     if sim_data == 'walking':
-        title_plot = 'Gait diagram: gen ' + str(int(generation)+1) if opt_res else 'Gait diagram' 
-        collisions = {'LF':[],'LM':[],'LH':[],'RF':[],'RM':[],'RH':[]}            
+        title_plot = 'Gait diagram: gen ' + \
+            str(int(generation) + 1) if opt_res else 'Gait diagram'
+        collisions = {
+            'LF': [],
+            'LM': [],
+            'LH': [],
+            'RF': [],
+            'RM': [],
+            'RH': []}
         for leg, force in data.items():
             collisions[leg[:2]].append(force.transpose()[0])
-            
+
     elif sim_data == 'grooming':
-        title_plot = 'Collisions diagram'        
-        collisions = {'LAntenna':[], 'LFTibia':[], 'LFTarsus1':[], 'LFTarsus2':[], 'LFTarsus3':[], 'LFTarsus4':[], 'LFTarsus5':[], 'RFTarsus5':[], 'RFTarsus4':[], 'RFTarsus3':[], 'RFTarsus2':[], 'RFTarsus1':[], 'RFTibia':[], 'RAntenna':[]}#, 'LEye':[], 'REye':[]}        
-        #for segment, coll in data.items():
+        title_plot = 'Collisions diagram'
+        collisions = {
+            'LAntenna': [],
+            'LFTibia': [],
+            'LFTarsus1': [],
+            'LFTarsus2': [],
+            'LFTarsus3': [],
+            'LFTarsus4': [],
+            'LFTarsus5': [],
+            'RFTarsus5': [],
+            'RFTarsus4': [],
+            'RFTarsus3': [],
+            'RFTarsus2': [],
+            'RFTarsus1': [],
+            'RFTibia': [],
+            'RAntenna': []}  # , 'LEye':[], 'REye':[]}
+        # for segment, coll in data.items():
         #    for key, forces in coll.items():
         #        if segment in collisions.keys():
         #            collisions[segment].append([np.linalg.norm(force) for force in forces])
@@ -412,211 +483,272 @@ def plot_collisions_diagram(sim_data, begin=0, end=0, opt_res=False, generation=
                 for key, vals in coll.items():
                     collisions[segment].append(vals.transpose()[0])
 
-    fig, axs = plt.subplots(len(collisions.keys()), sharex=True,gridspec_kw={'hspace': 0})
+    fig, axs = plt.subplots(len(collisions.keys()),
+                            sharex=True, gridspec_kw={'hspace': 0})
     fig.suptitle(title_plot)
-    
+
     for i, (segment, force) in enumerate(collisions.items()):
-        sum_force = np.sum(np.array(force), axis = 0)
-        segment_force = np.delete(sum_force,0)
-        time = np.arange(0,len(segment_force),1)/steps
-        stance_ind = np.where(segment_force>0)[0]
-        if stance_ind.size!=0:
+        sum_force = np.sum(np.array(force), axis=0)
+        segment_force = np.delete(sum_force, 0)
+        time = np.arange(0, len(segment_force), 1) / steps
+        stance_ind = np.where(segment_force > 0)[0]
+        if stance_ind.size != 0:
             stance_diff = np.diff(stance_ind)
-            stance_lim = np.where(stance_diff>1)[0]
-            stance=[stance_ind[0]-1]
+            stance_lim = np.where(stance_diff > 1)[0]
+            stance = [stance_ind[0] - 1]
             for ind in stance_lim:
-                stance.append(stance_ind[ind]+1)
-                stance.append(stance_ind[ind+1]-1)
+                stance.append(stance_ind[ind] + 1)
+                stance.append(stance_ind[ind + 1] - 1)
             stance.append(stance_ind[-1])
             start_gait_list = np.where(np.array(stance) >= start)[0]
-            if len(start_gait_list)>0:
+            if len(start_gait_list) > 0:
                 start_gait = start_gait_list[0]
             else:
-                start_gait = start            
+                start_gait = start
             stop_gait_list = np.where(np.array(stance) <= stop)[0]
-            if len(stop_gait_list)>0:
-                stop_gait = stop_gait_list[-1]+1
+            if len(stop_gait_list) > 0:
+                stop_gait = stop_gait_list[-1] + 1
             else:
                 stop_gait = start_gait
             stance_plot = stance[start_gait:stop_gait]
-            if start_gait%2 != 0:
-                stance_plot.insert(0,start)
-            if len(stance_plot)%2 != 0:
+            if start_gait % 2 != 0:
+                stance_plot.insert(0, start)
+            if len(stance_plot) % 2 != 0:
                 stance_plot.append(stop)
 
-            for ind in range(0,len(stance_plot),2):
-                axs[i].fill_between(time[stance_plot[ind]:stance_plot[ind+1]], 0, 1, facecolor='black', alpha=1, transform=axs[i].get_xaxis_transform())
+            for ind in range(0, len(stance_plot), 2):
+                axs[i].fill_between(time[stance_plot[ind]:stance_plot[ind + 1]], 0, 1,
+                                    facecolor='black', alpha=1, transform=axs[i].get_xaxis_transform())
         else:
-            axs[i].fill_between(time[start:stop], 0, 1, facecolor='white', alpha=1, transform=axs[i].get_xaxis_transform())
+            axs[i].fill_between(time[start:stop],
+                                0,
+                                1,
+                                facecolor='white',
+                                alpha=1,
+                                transform=axs[i].get_xaxis_transform())
 
         axs[i].set_yticks((0.5,))
         axs[i].set_yticklabels((segment,))
 
-    axs[len(axs)-1].set_xlabel('Time (s)')
+    axs[len(axs) - 1].set_xlabel('Time (s)')
     if sim_data == 'walking':
         black_patch = mpatches.Patch(color='black', label='Stance')
     elif sim_data == 'grooming':
         black_patch = mpatches.Patch(color='black', label='Collision')
-    axs[0].legend(handles=[black_patch],loc= 'upper right',bbox_to_anchor=(1.1, 1))
+    axs[0].legend(
+        handles=[black_patch],
+        loc='upper right',
+        bbox_to_anchor=(
+            1.1,
+            1))
     plt.show()
 
-def plot_opt_res(begin=0,end=0,key='Coxa',plot_act=True,plot_torques=True,plot_angles=True,exp='',generation=''):
+
+def plot_opt_res(
+        begin=0,
+        end=0,
+        key='Coxa',
+        plot_act=True,
+        plot_torques=True,
+        plot_angles=True,
+        exp='',
+        generation=''):
     pkg_path = Path(pkgutil.get_loader("NeuroMechFly").get_filename())
-    opt_res_folder = os.path.join(pkg_path.parents[1],'scripts/Optimization/Output_data')
-    
-    muscles_data = opt_res_folder + '/muscles/' + exp + '/outputs_optimization_gen_'+generation+'.h5'
-    angles_data = opt_res_folder + '/angles/' + exp + '/jointpos_optimization_gen_'+generation+'.h5'
+    opt_res_folder = os.path.join(
+        pkg_path.parents[1],
+        'scripts/Optimization/Output_data')
+
+    muscles_data = opt_res_folder + '/muscles/' + exp + \
+        '/outputs_optimization_gen_' + generation + '.h5'
+    angles_data = opt_res_folder + '/angles/' + exp + \
+        '/jointpos_optimization_gen_' + generation + '.h5'
 
     if end == 0:
         end = 5.0
 
-    start = int(begin*1000)
-    stop = int(end*1000)
+    start = int(begin * 1000)
+    stop = int(end * 1000)
 
-    data2plot={}
+    data2plot = {}
     mn_flex = {}
     mn_ext = {}
     torques = {}
     angles = {}
     if plot_act:
-        data= pd.read_hdf(muscles_data)
+        data = pd.read_hdf(muscles_data)
         for joint, val in data.items():
-            if key in joint and 'act' in joint and 'active' not in joint and ('Coxa' in joint or 'Femur' in joint or 'Tibia' in joint):
+            if key in joint and 'act' in joint and 'active' not in joint and (
+                    'Coxa' in joint or 'Femur' in joint or 'Tibia' in joint):
                 if key == 'Coxa' and ('M' in joint or 'H' in joint):
                     if 'roll' in joint:
-                        name = joint.split('_')[1]+' roll '+joint.split('_')[3]
+                        name = joint.split('_')[1] + \
+                            ' roll ' + joint.split('_')[3]
                         if 'flexor' in joint:
-                            mn_flex[name]=val
+                            mn_flex[name] = val
                         elif 'extensor' in joint:
-                            mn_ext[name]=val
+                            mn_ext[name] = val
                 else:
-                    name = joint.split('_')[1]+' '+joint.split('_')[2]
+                    name = joint.split('_')[1] + ' ' + joint.split('_')[2]
 
                     if 'flexor' in joint:
-                        mn_flex[name]=val
+                        mn_flex[name] = val
                     elif 'extensor' in joint:
-                        mn_ext[name]=val
-                    
+                        mn_ext[name] = val
+
         data2plot['mn_flex'] = mn_flex
         data2plot['mn_ext'] = mn_ext
 
-
     if plot_torques:
-        data= pd.read_hdf(muscles_data)
+        data = pd.read_hdf(muscles_data)
         for joint, val in data.items():
-            if key in joint and 'torque' in joint and ('Coxa' in joint or 'Femur' in joint or 'Tibia' in joint):
+            if key in joint and 'torque' in joint and (
+                    'Coxa' in joint or 'Femur' in joint or 'Tibia' in joint):
                 if key == 'Coxa' and ('M' in joint or 'H' in joint):
                     if 'roll' in joint:
-                        name = joint.split('_')[1]+' roll'
-                        torques[name]=val
+                        name = joint.split('_')[1] + ' roll'
+                        torques[name] = val
                 else:
                     name = joint.split('_')[1]
-                    torques[name]=val
-        data2plot['torques']=torques
+                    torques[name] = val
+        data2plot['torques'] = torques
     if plot_angles:
-        data= pd.read_hdf(angles_data)
+        data = pd.read_hdf(angles_data)
         for joint, val in data.items():
-            if key in joint:# and ('Coxa' in joint or 'Femur' in joint or 'Tibia' in joint):
+            # and ('Coxa' in joint or 'Femur' in joint or 'Tibia' in joint):
+            if key in joint:
                 joint_name = joint.split('_')
-                if len(joint_name)>2:
+                if len(joint_name) > 2:
                     if 'roll' in joint and ('M' in joint or 'H' in joint):
-                        name = joint_name[1]+' '+joint_name[2]
-                        angles[name]=val
+                        name = joint_name[1] + ' ' + joint_name[2]
+                        angles[name] = val
                 else:
                     if 'F' in joint:
                         name = joint.split('_')[1]
-                        angles[name]=val
-        data2plot['angles']=angles
+                        angles[name] = val
+        data2plot['angles'] = angles
 
     fig, axs = plt.subplots(len(data2plot.keys()), sharex=True)
 
     for i, (plot, data) in enumerate(data2plot.items()):
         if plot == 'mn_flex' or plot == 'mn_ext':
             for joint, act in data.items():
-                time = np.arange(0,len(act),1)/1000
-                axs[i].plot(time[start:stop], act[start:stop],label=joint)
-            axs[i].set_ylabel('MN activation - ' + plot.split('_')[1] + ' (a.u.)')
-            axs[i].set_ylim(0.3,2.1)
+                time = np.arange(0, len(act), 1) / 1000
+                axs[i].plot(time[start:stop], act[start:stop], label=joint)
+            axs[i].set_ylabel(
+                'MN activation - ' +
+                plot.split('_')[1] +
+                ' (a.u.)')
+            axs[i].set_ylim(0.3, 2.1)
 
         if plot == 'torques':
             for joint, torq in data.items():
-                time = np.arange(0,len(torq),1)/1000
-                axs[i].plot(time[start:stop], torq[start:stop]*100,label=joint)
+                time = np.arange(0, len(torq), 1) / 1000
+                axs[i].plot(time[start:stop], torq[start:stop]
+                            * 100, label=joint)
             axs[i].set_ylabel('Joint torque ' + r'$(\mu Nm)$')
-            axs[i].set_ylim(-2,2)
+            axs[i].set_ylim(-2, 2)
 
         if plot == 'angles':
             for joint, ang in data.items():
-                time = np.arange(0,len(ang),1)/1000
-                axs[i].plot(time[start:stop], ang[start:stop]*180/np.pi,label=joint)
-            axs[i].set_ylabel('Joint angle (deg)')        
-            
+                time = np.arange(0, len(ang), 1) / 1000
+                axs[i].plot(time[start:stop], ang[start:stop]
+                            * 180 / np.pi, label=joint)
+            axs[i].set_ylabel('Joint angle (deg)')
+
         axs[i].grid(True)
         axs[i].legend()
 
-    axs[len(axs)-1].set_xlabel('Time (s)')
+    axs[len(axs) - 1].set_xlabel('Time (s)')
     plt.show()
-    
 
-def plot_fly_path2(begin=0, end=0, sequence=False, save_imgs=False, exp='', heading=True, opt_res=False,generations=[]):
 
-    ball_data_list=[]
-    colors = ['winter','copper','Purples','Greens','Oranges']
+def plot_fly_path2(
+        begin=0,
+        end=0,
+        sequence=False,
+        save_imgs=False,
+        exp='',
+        heading=True,
+        opt_res=False,
+        generations=[]):
 
-    fig = plt.figure()  
+    ball_data_list = []
+    colors = ['winter', 'copper', 'Purples', 'Greens', 'Oranges']
+
+    fig = plt.figure()
     ax = plt.axes()
     m = MarkerStyle(marker=r'$\rightarrow$')
     ax.set_xlabel('x (mm)')
     ax.set_ylabel('y (mm)')
 
     val_max = 0
-    
+
     pkg_path = Path(pkgutil.get_loader("NeuroMechFly").get_filename())
-    
+
     if not opt_res:
-        sim_res_folder = os.path.join(pkg_path.parents[1],'scripts/KM/results')
-        ball_data_list.append(sim_res_folder + '/ballRot_data_ball_walking.pkl')
+        sim_res_folder = os.path.join(
+            pkg_path.parents[1], 'scripts/KM/results')
+        ball_data_list.append(
+            sim_res_folder +
+            '/ballRot_data_ball_walking.pkl')
     else:
-        sim_res_folder = os.path.join(pkg_path.parents[1],'scripts/Optimization/Output_data/ballRotations',exp)
+        sim_res_folder = os.path.join(
+            pkg_path.parents[1],
+            'scripts/Optimization/Output_data/ballRotations',
+            exp)
         for gen in generations:
-            ball_data_list.append(sim_res_folder +'/ballRot_optimization_gen_'+gen+'.pkl')
-        
+            ball_data_list.append(
+                sim_res_folder +
+                '/ballRot_optimization_gen_' +
+                gen +
+                '.pkl')
+
     for ind, ball_data in enumerate(ball_data_list):
 
         with open(ball_data, 'rb') as fp:
             data = pickle.load(fp)
 
         if end == 0:
-            end = len(data)            
+            end = len(data)
 
         data_array = np.array(data)
         x_diff = np.diff(-data_array.transpose()[0])
         y_diff = np.diff(data_array.transpose()[1])
         #th = -np.diff(data_array.transpose()[2])
 
-        x=[0]
-        y=[0]
-        for i in range(begin,end-1):#, coords in enumerate(x_diff[begin:end]):
+        x = [0]
+        y = [0]
+        # , coords in enumerate(x_diff[begin:end]):
+        for i in range(begin, end - 1):
             if heading:
                 th = data[i][2]
-                x_new = x_diff[i]*np.cos(th) - y_diff[i]*np.sin(th)
-                y_new = y_diff[i]*np.cos(th) + x_diff[i]*np.sin(th)
-                x.append(x[-1]+x_new)
-                y.append(y[-1]+y_new)
+                x_new = x_diff[i] * np.cos(th) - y_diff[i] * np.sin(th)
+                y_new = y_diff[i] * np.cos(th) + x_diff[i] * np.sin(th)
+                x.append(x[-1] + x_new)
+                y.append(y[-1] + y_new)
             else:
                 x.append(data[i][0])
                 y.append(data[i][1])
 
             if sequence:
-                print('\rFrame: ' + str(i),end='')
-                sc = ax.scatter(x,y,c=np.linspace(begin/100,len(x)/100,len(x)),cmap='winter',vmin=begin/100,vmax=end/100)
+                print('\rFrame: ' + str(i), end='')
+                sc = ax.scatter(
+                    x,
+                    y,
+                    c=np.linspace(
+                        begin / 100,
+                        len(x) / 100,
+                        len(x)),
+                    cmap='winter',
+                    vmin=begin / 100,
+                    vmax=end / 100)
 
-                m._transform.rotate_deg(th*180/np.pi)        
-                ax.scatter(x[-1], y[-1], marker=m, s=200,color='black')
-                m._transform.rotate_deg(-th*180/np.pi)
+                m._transform.rotate_deg(th * 180 / np.pi)
+                ax.scatter(x[-1], y[-1], marker=m, s=200, color='black')
+                m._transform.rotate_deg(-th * 180 / np.pi)
 
                 if i == 0:
-                    sc.set_clim([begin/100,end/100])
+                    sc.set_clim([begin / 100, end / 100])
                     cb = plt.colorbar(sc)
                     cb.set_label('Time (s)')
 
@@ -624,11 +756,12 @@ def plot_fly_path2(begin=0, end=0, sequence=False, save_imgs=False, exp='', head
                 ax.set_ylabel('y (mm)')
                 if save_imgs:
                     file_name = exp.split('/')[-1]
-                    new_folder = 'results/'+file_name.replace('.pkl','/')+'fly_path'
+                    new_folder = 'results/' + \
+                        file_name.replace('.pkl', '/') + 'fly_path'
                     if not os.path.exists(new_folder):
                         os.makedirs(new_folder)
                     name = new_folder + '/img_' + '{:06}'.format(i) + '.jpg'
-                    fig.set_size_inches(6,4)
+                    fig.set_size_inches(6, 4)
                     plt.savefig(name, dpi=300)
                 else:
                     plt.draw()
@@ -640,45 +773,63 @@ def plot_fly_path2(begin=0, end=0, sequence=False, save_imgs=False, exp='', head
 
             if max_x > val_max:
                 val_max = max_x
-            
-            lim = val_max + 0.05*val_max        
+
+            lim = val_max + 0.05 * val_max
             ax.set_xlim(-2, lim)
-            ax.set_ylim(-lim/2, lim/2)
+            ax.set_ylim(-lim / 2, lim / 2)
 
         if not sequence:
             #sc = ax.scatter(x,y,c=np.arange(begin/100,end/100,0.01),cmap=colors[ind])
-            #sc.set_clim([begin/100,end/100])
+            # sc.set_clim([begin/100,end/100])
             #cb = plt.colorbar(sc)
-            #if ind==0:
+            # if ind==0:
             #    cb.set_label('Time (s)')
-            ax.plot(x,y,linewidth=2,label='Gen ' + str(int(generations[ind])+1))
+            ax.plot(x, y, linewidth=2, label='Gen ' +
+                    str(int(generations[ind]) + 1))
     ax.legend()
     plt.show()
-    
 
-def plot_fly_path(begin=0, end=0, sequence=True, save_imgs=False, experiment='', heading=True, opt_res=False):
 
-    ball_data_list=[]
-    colors = ['winter','copper','Purples','Greens','Oranges']
+def plot_fly_path(
+        begin=0,
+        end=0,
+        sequence=True,
+        save_imgs=False,
+        experiment='',
+        heading=True,
+        opt_res=False):
 
-    fig = plt.figure()  
+    ball_data_list = []
+    colors = ['winter', 'copper', 'Purples', 'Greens', 'Oranges']
+
+    fig = plt.figure()
     ax = plt.axes()
     m = MarkerStyle(marker=r'$\rightarrow$')
     ax.set_xlabel('x (mm)')
     ax.set_ylabel('y (mm)')
 
     val_max = 0
-    
+
     if not opt_res:
         sim_res_folder = '/home/nely/SimFly/kinematic_matching/results/'
         ball_data_list.append(sim_res_folder + 'ballRot_data_ball_walking.pkl')
     else:
-        sim_res_folder='/home/nely/SimFly/GIT/farms_models_data/drosophila_v3/simulation/ball_data/'
-        ball_data_list.append(sim_res_folder + 'ballRot_data_optimization_49.pkl')
-        ball_data_list.append(sim_res_folder + 'ballRot_data_optimization_37.pkl')
-        ball_data_list.append(sim_res_folder + 'ballRot_data_optimization_24.pkl')
-        ball_data_list.append(sim_res_folder + 'ballRot_data_optimization_12.pkl')
-        ball_data_list.append(sim_res_folder + 'ballRot_data_optimization_0.pkl')
+        sim_res_folder = '/home/nely/SimFly/GIT/farms_models_data/drosophila_v3/simulation/ball_data/'
+        ball_data_list.append(
+            sim_res_folder +
+            'ballRot_data_optimization_49.pkl')
+        ball_data_list.append(
+            sim_res_folder +
+            'ballRot_data_optimization_37.pkl')
+        ball_data_list.append(
+            sim_res_folder +
+            'ballRot_data_optimization_24.pkl')
+        ball_data_list.append(
+            sim_res_folder +
+            'ballRot_data_optimization_12.pkl')
+        ball_data_list.append(
+            sim_res_folder +
+            'ballRot_data_optimization_0.pkl')
 
     for ind, ball_data in enumerate(ball_data_list):
 
@@ -686,38 +837,46 @@ def plot_fly_path(begin=0, end=0, sequence=True, save_imgs=False, experiment='',
             data = pickle.load(fp)
 
         if end == 0:
-            end = len(data)    
-
-        
+            end = len(data)
 
         data_array = np.array(data)
         x_diff = np.diff(-data_array.transpose()[0])
         y_diff = np.diff(data_array.transpose()[1])
         #th = -np.diff(data_array.transpose()[2])
 
-        x=[0]
-        y=[0]
-        for i in range(begin,end-1):#, coords in enumerate(x_diff[begin:end]):
+        x = [0]
+        y = [0]
+        # , coords in enumerate(x_diff[begin:end]):
+        for i in range(begin, end - 1):
             if heading:
                 th = data[i][2]
-                x_new = x_diff[i]*np.cos(th) - y_diff[i]*np.sin(th)
-                y_new = y_diff[i]*np.cos(th) + x_diff[i]*np.sin(th)
-                x.append(x[-1]+x_new)
-                y.append(y[-1]+y_new)
+                x_new = x_diff[i] * np.cos(th) - y_diff[i] * np.sin(th)
+                y_new = y_diff[i] * np.cos(th) + x_diff[i] * np.sin(th)
+                x.append(x[-1] + x_new)
+                y.append(y[-1] + y_new)
             else:
                 x.append(data[i][0])
                 y.append(data[i][1])
 
             if sequence:
-                print('\rFrame: ' + str(i),end='')
-                sc = ax.scatter(x,y,c=np.linspace(begin/100,len(x)/100,len(x)),cmap='winter',vmin=begin/100,vmax=end/100)
+                print('\rFrame: ' + str(i), end='')
+                sc = ax.scatter(
+                    x,
+                    y,
+                    c=np.linspace(
+                        begin / 100,
+                        len(x) / 100,
+                        len(x)),
+                    cmap='winter',
+                    vmin=begin / 100,
+                    vmax=end / 100)
 
-                m._transform.rotate_deg(th*180/np.pi)        
-                ax.scatter(x[-1], y[-1], marker=m, s=200,color='black')
-                m._transform.rotate_deg(-th*180/np.pi)
+                m._transform.rotate_deg(th * 180 / np.pi)
+                ax.scatter(x[-1], y[-1], marker=m, s=200, color='black')
+                m._transform.rotate_deg(-th * 180 / np.pi)
 
                 if i == 0:
-                    sc.set_clim([begin/100,end/100])
+                    sc.set_clim([begin / 100, end / 100])
                     cb = plt.colorbar(sc)
                     cb.set_label('Time (s)')
 
@@ -725,11 +884,12 @@ def plot_fly_path(begin=0, end=0, sequence=True, save_imgs=False, experiment='',
                 ax.set_ylabel('y (mm)')
                 if save_imgs:
                     file_name = experiment.split('/')[-1]
-                    new_folder = 'results/'+file_name.replace('.pkl','/')+'fly_path'
+                    new_folder = 'results/' + \
+                        file_name.replace('.pkl', '/') + 'fly_path'
                     if not os.path.exists(new_folder):
                         os.makedirs(new_folder)
                     name = new_folder + '/img_' + '{:06}'.format(i) + '.jpg'
-                    fig.set_size_inches(6,4)
+                    fig.set_size_inches(6, 4)
                     plt.savefig(name, dpi=300)
                 else:
                     plt.draw()
@@ -741,18 +901,26 @@ def plot_fly_path(begin=0, end=0, sequence=True, save_imgs=False, experiment='',
 
             if max_x > val_max:
                 val_max = max_x
-            
-            lim = val_max + 0.05*val_max        
+
+            lim = val_max + 0.05 * val_max
             ax.set_xlim(-2, lim)
-            ax.set_ylim(-lim/2, lim/2)
+            ax.set_ylim(-lim / 2, lim / 2)
 
         if not sequence:
-            sc = ax.scatter(x,y,c=np.arange(begin/100,end/100,0.01),cmap=colors[ind])
-            sc.set_clim([begin/100,end/100])
+            sc = ax.scatter(
+                x,
+                y,
+                c=np.arange(
+                    begin / 100,
+                    end / 100,
+                    0.01),
+                cmap=colors[ind])
+            sc.set_clim([begin / 100, end / 100])
             cb = plt.colorbar(sc)
-            if ind==0:
-                cb.set_label('Time (s)')        
+            if ind == 0:
+                cb.set_label('Time (s)')
     plt.show()
+
 
 def read_collision_forces(path_data):
     """ Reads collision force's data obtained after running a simulation.
@@ -767,7 +935,8 @@ def read_collision_forces(path_data):
     collisions: <dict>
         Collision forces for all segments in all legs.
     """
-    collisions_data = os.path.join(path_data, 'physics', 'contact_normal_force.h5')
+    collisions_data = os.path.join(
+        path_data, 'physics', 'contact_normal_force.h5')
     data = pd.read_hdf(collisions_data)
 
     collisions = {}
@@ -792,7 +961,7 @@ def read_collision_forces(path_data):
                 collisions[segment2] = {}
                 x_force[segment2] = {}
                 z_force[segment2] = {}
-                
+
             collisions[segment1][segment2] = res_force
             collisions[segment2][segment1] = res_force
 
@@ -803,148 +972,228 @@ def read_collision_forces(path_data):
             z_force[segment2][segment1] = data_z
 
     return collisions, x_force, z_force
-    
-def draw_collisions_on_imgs(data_2d, experiment, path_data, sim_data='grooming', side='R', begin=0, end=0, save_imgs=False,pause=0,grfScalingFactor=1e6, scale=30,tot_time=9.0, time_step_data=0.0005, time_step_img=0.01):
-    data={}
+
+
+def draw_collisions_on_imgs(
+        data_2d,
+        experiment,
+        path_data,
+        sim_data='grooming',
+        side='R',
+        begin=0,
+        end=0,
+        save_imgs=False,
+        pause=0,
+        grfScalingFactor=1e6,
+        scale=30,
+        tot_time=9.0,
+        time_step_data=0.0005,
+        time_step_img=0.01):
+    data = {}
     length_data = 0
 
-    colors = {'a':(0,0,139),'1':(0,0,255),'2':(71,99,255),'3':(92,92,205),'4':(128,128,240),'5':(122,160,255)}
+    colors = {
+        'a': (
+            0, 0, 139), '1': (
+            0, 0, 255), '2': (
+                71, 99, 255), '3': (
+                    92, 92, 205), '4': (
+                        128, 128, 240), '5': (
+                            122, 160, 255)}
 
     if end == 0:
         end = tot_time
 
-    steps_data = 1/time_step_data
-    steps_img = 1/time_step_img
-    diff_steps = time_step_img/time_step_data
-    start = int(begin*steps_data)
-    stop = int(end*steps_data)
-    start_img = int(begin*steps_img)+1
-    stop_img = int(end*steps_img)+2
-    
+    steps_data = 1 / time_step_data
+    steps_img = 1 / time_step_img
+    diff_steps = time_step_img / time_step_data
+    start = int(begin * steps_data)
+    stop = int(end * steps_data)
+    start_img = int(begin * steps_img) + 1
+    stop_img = int(end * steps_img) + 2
+
     data, x_f, z_f = read_collision_forces(path_data)
-    
-    collisions = {'LAntenna':[], 'LFTibia':[], 'LFTarsus1':[], 'LFTarsus2':[], 'LFTarsus3':[], 'LFTarsus4':[], 'LFTarsus5':[], 'RFTarsus5':[], 'RFTarsus4':[], 'RFTarsus3':[], 'RFTarsus2':[], 'RFTarsus1':[], 'RFTibia':[], 'RAntenna':[]}#, 'LEye':[], 'REye':[]}
 
+    collisions = {
+        'LAntenna': [],
+        'LFTibia': [],
+        'LFTarsus1': [],
+        'LFTarsus2': [],
+        'LFTarsus3': [],
+        'LFTarsus4': [],
+        'LFTarsus5': [],
+        'RFTarsus5': [],
+        'RFTarsus4': [],
+        'RFTarsus3': [],
+        'RFTarsus2': [],
+        'RFTarsus1': [],
+        'RFTibia': [],
+        'RAntenna': []}  # , 'LEye':[], 'REye':[]}
 
-    x_force = {'LAntenna':[], 'LFTibia':[], 'LFTarsus1':[], 'LFTarsus2':[], 'LFTarsus3':[], 'LFTarsus4':[], 'LFTarsus5':[], 'RFTarsus5':[], 'RFTarsus4':[], 'RFTarsus3':[], 'RFTarsus2':[], 'RFTarsus1':[], 'RFTibia':[], 'RAntenna':[]}
+    x_force = {
+        'LAntenna': [],
+        'LFTibia': [],
+        'LFTarsus1': [],
+        'LFTarsus2': [],
+        'LFTarsus3': [],
+        'LFTarsus4': [],
+        'LFTarsus5': [],
+        'RFTarsus5': [],
+        'RFTarsus4': [],
+        'RFTarsus3': [],
+        'RFTarsus2': [],
+        'RFTarsus1': [],
+        'RFTibia': [],
+        'RAntenna': []}
 
-    z_force = {'LAntenna':[], 'LFTibia':[], 'LFTarsus1':[], 'LFTarsus2':[], 'LFTarsus3':[], 'LFTarsus4':[], 'LFTarsus5':[], 'RFTarsus5':[], 'RFTarsus4':[], 'RFTarsus3':[], 'RFTarsus2':[], 'RFTarsus1':[], 'RFTibia':[], 'RAntenna':[]}
+    z_force = {
+        'LAntenna': [],
+        'LFTibia': [],
+        'LFTarsus1': [],
+        'LFTarsus2': [],
+        'LFTarsus3': [],
+        'LFTarsus4': [],
+        'LFTarsus5': [],
+        'RFTarsus5': [],
+        'RFTarsus4': [],
+        'RFTarsus3': [],
+        'RFTarsus2': [],
+        'RFTarsus1': [],
+        'RFTibia': [],
+        'RAntenna': []}
 
     #angle = {'LAntenna':[], 'LFTibia':[], 'LFTarsus1':[], 'LFTarsus2':[], 'LFTarsus3':[], 'LFTarsus4':[], 'LFTarsus5':[], 'RFTarsus5':[], 'RFTarsus4':[], 'RFTarsus3':[], 'RFTarsus2':[], 'RFTarsus1':[], 'RFTibia':[], 'RAntenna':[]}
 
     for segment1 in collisions.keys():
-            seg_forces=[]
-            for segment2, force in data[segment1].items():
-                seg_forces.append(force)
-            sum_force = np.sum(np.array(seg_forces), axis=0)
-            segment_force = np.delete(sum_force, 0)
-            collisions[segment1].append(segment_force)
-            if length_data == 0:
-                length_data = len(segment_force)
+        seg_forces = []
+        for segment2, force in data[segment1].items():
+            seg_forces.append(force)
+        sum_force = np.sum(np.array(seg_forces), axis=0)
+        segment_force = np.delete(sum_force, 0)
+        collisions[segment1].append(segment_force)
+        if length_data == 0:
+            length_data = len(segment_force)
 
-            seg_forces=[]
-            for segment2, force in x_f[segment1].items():
-                seg_forces.append(force)
-            sum_force_x = np.sum(np.array(seg_forces), axis=0)
-            segment_force_x = np.delete(sum_force_x, 0)
-            x_force[segment1].append(segment_force_x)
+        seg_forces = []
+        for segment2, force in x_f[segment1].items():
+            seg_forces.append(force)
+        sum_force_x = np.sum(np.array(seg_forces), axis=0)
+        segment_force_x = np.delete(sum_force_x, 0)
+        x_force[segment1].append(segment_force_x)
 
-            seg_forces=[]
-            for segment2, force in z_f[segment1].items():
-                seg_forces.append(force)
-            sum_force_z = np.sum(np.array(seg_forces), axis=0)
-            segment_force_z = np.delete(sum_force_z, 0)
-            z_force[segment1].append(segment_force_z)
+        seg_forces = []
+        for segment2, force in z_f[segment1].items():
+            seg_forces.append(force)
+        sum_force_z = np.sum(np.array(seg_forces), axis=0)
+        segment_force_z = np.delete(sum_force_z, 0)
+        z_force[segment1].append(segment_force_z)
 
-            #ang = np.arctan2(segment_force_z,segment_force_x)
-            #angle[segment1].append(ang)
-    
-    #for key, val in all_collisions.items():
+        #ang = np.arctan2(segment_force_z,segment_force_x)
+        # angle[segment1].append(ang)
+
+    # for key, val in all_collisions.items():
     #    if side in key and 'Antenna' not in key:
     #        forces[key]=val
     #        angles[key]=val
 
-    #for segment, coll in data.items():
+    # for segment, coll in data.items():
     #    if segment in forces.keys():
     #        for key, vals in coll.items():
     #            #if key in all_collisions.keys():
-    #            forces[segment].append(vals.transpose()[0])                    
+    #            forces[segment].append(vals.transpose()[0])
     #            angles[segment].append(vals.transpose()[1])
 
-    raw_imgs=[]
+    raw_imgs = []
     ind_folder = experiment.find('df3d')
-    imgs_folder = experiment[:ind_folder-1]
+    imgs_folder = experiment[:ind_folder - 1]
 
-    for frame in range(start_img,stop_img):
-        if side=='R':
+    for frame in range(start_img, stop_img):
+        if side == 'R':
             cam_num = 1
-        elif side=='L':
+        elif side == 'L':
             cam_num = 5
-        img_name = imgs_folder + '/camera_' +str(cam_num)+ '_img_' + '{:06}'.format(frame) + '.jpg'
-        #print(img_name)
+        img_name = imgs_folder + '/camera_' + \
+            str(cam_num) + '_img_' + '{:06}'.format(frame) + '.jpg'
+        # print(img_name)
         img = cv.imread(img_name)
         raw_imgs.append(img)
 
     for i, (leg, force) in enumerate(collisions.items()):
-        if side in leg and not 'Antenna' in leg:
-            stance_plot = get_stance_periods(force[0],start,stop)
+        if side in leg and 'Antenna' not in leg:
+            stance_plot = get_stance_periods(force[0], start, stop)
             bodyPart = leg[2:]
             if 'Tarsus' in bodyPart:
                 bodyPart = 'Claw'
                 prev = 'Tarsus'
                 if '1' in leg[2:]:
-                    div = 1/5
+                    div = 1 / 5
                 elif '2' in leg[2:]:
-                    div = 2/6
+                    div = 2 / 6
                 elif '3' in leg[2:]:
-                    div = 3/6
+                    div = 3 / 6
                 elif '4' in leg[2:]:
-                    div = 4/6
+                    div = 4 / 6
                 elif '5' in leg[2:]:
-                    div = 5/6
+                    div = 5 / 6
             if 'Tibia' in bodyPart:
                 bodyPart = 'Tarsus'
                 prev = 'Tarsus'
                 div = 1
-            for ind in range(0,len(stance_plot),2):
-                for frame in range(stance_plot[ind],stance_plot[ind+1],int(diff_steps)):
-                    cam_frame = int(frame/diff_steps)+1
-                    img_frame = int((frame-start)/diff_steps)
+            for ind in range(0, len(stance_plot), 2):
+                for frame in range(
+                        stance_plot[ind], stance_plot[ind + 1], int(diff_steps)):
+                    cam_frame = int(frame / diff_steps) + 1
+                    img_frame = int((frame - start) / diff_steps)
 
-                    x_base = data_2d[cam_num][side+'F_leg'][bodyPart][cam_frame][0]
-                    y_base = data_2d[cam_num][side+'F_leg'][bodyPart][cam_frame][1]
+                    x_base = data_2d[cam_num][side +
+                                              'F_leg'][bodyPart][cam_frame][0]
+                    y_base = data_2d[cam_num][side +
+                                              'F_leg'][bodyPart][cam_frame][1]
 
-                    x_prev = data_2d[cam_num][side+'F_leg'][prev][cam_frame][0]
-                    y_prev = data_2d[cam_num][side+'F_leg'][prev][cam_frame][1]
+                    x_prev = data_2d[cam_num][side +
+                                              'F_leg'][prev][cam_frame][0]
+                    y_prev = data_2d[cam_num][side +
+                                              'F_leg'][prev][cam_frame][1]
 
-                    x_px = int(x_prev + div*(x_base-x_prev))
-                    y_px = int(y_prev + div*(y_base-y_prev))
+                    x_px = int(x_prev + div * (x_base - x_prev))
+                    y_px = int(y_prev + div * (y_base - y_prev))
 
-                    start_pnt = [x_px, y_px]                    
-                    
-                    force_x = np.sum(x_force[leg][0][stance_plot[ind]:stance_plot[ind]+int(diff_steps)])*grfScalingFactor
-                    force_z = np.sum(z_force[leg][0][stance_plot[ind]:stance_plot[ind]+int(diff_steps)])*grfScalingFactor
-                    
+                    start_pnt = [x_px, y_px]
+
+                    force_x = np.sum(
+                        x_force[leg][0][stance_plot[ind]:stance_plot[ind] + int(diff_steps)]) * grfScalingFactor
+                    force_z = np.sum(
+                        z_force[leg][0][stance_plot[ind]:stance_plot[ind] + int(diff_steps)]) * grfScalingFactor
+
                     h, w, c = raw_imgs[img_frame].shape
-                    end_pnt = [x_px+(force_x*h/(2*scale)), y_px-(force_z*h/(2*scale))]
-                    
+                    end_pnt = [x_px + (force_x * h / (2 * scale)),
+                               y_px - (force_z * h / (2 * scale))]
+
                     color = colors[leg[-1]]
-                    raw_imgs[img_frame] = draw_lines(raw_imgs[img_frame],start_pnt,end_pnt,color=color,thickness=3,arrowHead=True)
-                       
+                    raw_imgs[img_frame] = draw_lines(
+                        raw_imgs[img_frame],
+                        start_pnt,
+                        end_pnt,
+                        color=color,
+                        thickness=3,
+                        arrowHead=True)
+
     for i, img in enumerate(raw_imgs):
-        print('\rFrame: ' + str(i+start_img),end='')
+        print('\rFrame: ' + str(i + start_img), end='')
         if save_imgs:
             file_name = experiment.split('/')[-1]
-            new_folder = 'results/'+file_name.replace('.pkl','/')+'collisions_on_raw'
+            new_folder = 'results/' + \
+                file_name.replace('.pkl', '/') + 'collisions_on_raw'
             if not os.path.exists(new_folder):
                 os.makedirs(new_folder)
             name = new_folder + '/img_' + '{:06}'.format(i) + '.jpg'
-            cv.imwrite(name,img)
+            cv.imwrite(name, img)
         else:
             #print(np.array(grf['LF']).transpose()[i+start+1], np.array(angle['LF']).transpose()[i+start+1]*180/np.pi)
-            cv.imshow('img',img)
+            cv.imshow('img', img)
             cv.waitKey(pause)
     cv.destroyAllWindows()
+
 
 def read_ground_contacts(path_data):
     """ Reads ground contact's data obtained after running a simulation.
@@ -984,7 +1233,8 @@ def read_ground_contacts(path_data):
 
     return grf, x_force, z_force
 
-def get_stance_periods(leg_force,start,stop):
+
+def get_stance_periods(leg_force, start, stop):
     """ Get stance periods from GRF data.
 
     Parameters
@@ -1015,7 +1265,9 @@ def get_stance_periods(leg_force,start,stop):
             start_gait = start_gait_list[0]
         else:
             start_gait = start
-        stop_gait_list = np.where((np.array(stance) <= stop)&(np.array(stance) > start))[0]
+        stop_gait_list = np.where(
+            (np.array(stance) <= stop) & (
+                np.array(stance) > start))[0]
         if len(stop_gait_list) > 0:
             stop_gait = stop_gait_list[-1] + 1
         else:
@@ -1032,29 +1284,51 @@ def get_stance_periods(leg_force,start,stop):
         stance_plot = [start, start]
 
     return stance_plot
-    
-def draw_grf_on_imgs(data_2d, experiment, path_data, sim_data='walking', side='R', begin=0, end=0, save_imgs=False,pause=0,grfScalingFactor=1e6,scale=15,tot_time=10.0, time_step_data=0.0005, time_step_img=0.01):
-    data={}
+
+
+def draw_grf_on_imgs(
+        data_2d,
+        experiment,
+        path_data,
+        sim_data='walking',
+        side='R',
+        begin=0,
+        end=0,
+        save_imgs=False,
+        pause=0,
+        grfScalingFactor=1e6,
+        scale=15,
+        tot_time=10.0,
+        time_step_data=0.0005,
+        time_step_img=0.01):
+    data = {}
     length_data = 0
 
-    colors = {'RF_leg':(0,0,204),'RM_leg':(51,51,255),'RH_leg':(102,102,255),'LF_leg':(153,76,0),'LM_leg':(255,128,0),'LH_leg':(255,178,102)}
+    colors = {
+        'RF_leg': (
+            0, 0, 204), 'RM_leg': (
+            51, 51, 255), 'RH_leg': (
+                102, 102, 255), 'LF_leg': (
+                    153, 76, 0), 'LM_leg': (
+                        255, 128, 0), 'LH_leg': (
+                            255, 178, 102)}
 
     if end == 0:
         end = tot_time
 
-    steps_data = 1/time_step_data
-    steps_img = 1/time_step_img
-    diff_steps = time_step_img/time_step_data
-    start = int(begin*steps_data)
-    stop = int(end*steps_data)
-    start_img = int((begin+14.0)*steps_img)+1
-    stop_img = int((end+14.0)*steps_img)+2
+    steps_data = 1 / time_step_data
+    steps_img = 1 / time_step_img
+    diff_steps = time_step_img / time_step_data
+    start = int(begin * steps_data)
+    stop = int(end * steps_data)
+    start_img = int((begin + 14.0) * steps_img) + 1
+    stop_img = int((end + 14.0) * steps_img) + 2
 
-    grf = {'LF':[],'LM':[],'LH':[],'RF':[],'RM':[],'RH':[]}
+    grf = {'LF': [], 'LM': [], 'LH': [], 'RF': [], 'RM': [], 'RH': []}
     #angle = {'LF':[],'LM':[],'LH':[],'RF':[],'RM':[],'RH':[]}
-    x_force = {'LF':[],'LM':[],'LH':[],'RF':[],'RM':[],'RH':[]}
-    z_force = {'LF':[],'LM':[],'LH':[],'RF':[],'RM':[],'RH':[]}
-    
+    x_force = {'LF': [], 'LM': [], 'LH': [], 'RF': [], 'RM': [], 'RH': []}
+    z_force = {'LF': [], 'LM': [], 'LH': [], 'RF': [], 'RM': [], 'RH': []}
+
     data, x_f, z_f = read_ground_contacts(path_data)
 
     for leg in grf.keys():
@@ -1067,166 +1341,234 @@ def draw_grf_on_imgs(data_2d, experiment, path_data, sim_data='walking', side='R
         sum_force_x = np.sum(np.array(x_f[leg]), axis=0)
         segment_force_x = np.delete(sum_force_x, 0)
         x_force[leg].append(segment_force_x)
-        
+
         sum_force_z = np.sum(np.array(z_f[leg]), axis=0)
         segment_force_z = np.delete(sum_force_z, 0)
         z_force[leg].append(segment_force_z)
-        
+
         #ang = np.arctan2(segment_force_z,segment_force_x)
-        #angle[leg].append(ang)
-    
-    raw_imgs=[]
+        # angle[leg].append(ang)
+
+    raw_imgs = []
     ind_folder = experiment.find('df3d')
-    imgs_folder = experiment[:ind_folder-1]
-    for frame in range(start_img,stop_img):
-        if side=='R':
+    imgs_folder = experiment[:ind_folder - 1]
+    for frame in range(start_img, stop_img):
+        if side == 'R':
             cam_num_img = 5
             cam_num_data = 1
-        elif side=='L':
+        elif side == 'L':
             cam_num_img = 1
             cam_num_data = 5
-        img_name = imgs_folder + '/images/camera_' +str(cam_num_img)+ '_img_' + '{}'.format(frame) + '.jpg'
+        img_name = imgs_folder + '/images/camera_' + \
+            str(cam_num_img) + '_img_' + '{}'.format(frame) + '.jpg'
         img = cv.imread(img_name)
         raw_imgs.append(img)
-    
+
     for i, (leg, force) in enumerate(grf.items()):
         if side in leg:
-            stance_plot = get_stance_periods(force[0],start,stop)
-            for ind in range(0,len(stance_plot),2):
-                for frame in range(stance_plot[ind],stance_plot[ind+1],int(diff_steps)):
-                    cam_frame = int(frame/diff_steps)+1
-                    img_frame = int((frame-start)/diff_steps)
-                        
-                    x_px = int(data_2d[cam_num_data][leg+'_leg']['Claw'][cam_frame][0])
-                    y_px = int(data_2d[cam_num_data][leg+'_leg']['Claw'][cam_frame][1])
+            stance_plot = get_stance_periods(force[0], start, stop)
+            for ind in range(0, len(stance_plot), 2):
+                for frame in range(
+                        stance_plot[ind], stance_plot[ind + 1], int(diff_steps)):
+                    cam_frame = int(frame / diff_steps) + 1
+                    img_frame = int((frame - start) / diff_steps)
+
+                    x_px = int(data_2d[cam_num_data]
+                               [leg + '_leg']['Claw'][cam_frame][0])
+                    y_px = int(data_2d[cam_num_data]
+                               [leg + '_leg']['Claw'][cam_frame][1])
                     start_pnt = [x_px, y_px]
-                    #np.array(grf['LF']).transpose()[i+start+1]
-                    
-                    force_x = x_force[leg][0][frame]*grfScalingFactor
-                    force_z = z_force[leg][0][frame]*grfScalingFactor
+                    # np.array(grf['LF']).transpose()[i+start+1]
+
+                    force_x = x_force[leg][0][frame] * grfScalingFactor
+                    force_z = z_force[leg][0][frame] * grfScalingFactor
                     h, w, c = raw_imgs[img_frame].shape
-                    end_pnt = [x_px+(force_x*h/(2*scale)), y_px-(force_z*h/(2*scale))]
-                    
-                    color = colors[leg+'_leg']
-                    raw_imgs[img_frame] = draw_lines(raw_imgs[img_frame],start_pnt,end_pnt,color=color,thickness=3,arrowHead=True)
-    
+                    end_pnt = [x_px + (force_x * h / (2 * scale)),
+                               y_px - (force_z * h / (2 * scale))]
+
+                    color = colors[leg + '_leg']
+                    raw_imgs[img_frame] = draw_lines(
+                        raw_imgs[img_frame],
+                        start_pnt,
+                        end_pnt,
+                        color=color,
+                        thickness=3,
+                        arrowHead=True)
+
     for i, img in enumerate(raw_imgs):
-        print('\rFrame: ' + str(i+start_img),end='')
+        print('\rFrame: ' + str(i + start_img), end='')
         if save_imgs:
             file_name = experiment.split('/')[-1]
-            new_folder = 'results/'+file_name.replace('.pkl','/')+'grf_on_raw'
+            new_folder = 'results/' + \
+                file_name.replace('.pkl', '/') + 'grf_on_raw'
             if not os.path.exists(new_folder):
                 os.makedirs(new_folder)
             name = new_folder + '/img_' + '{:06}'.format(i) + '.jpg'
-            cv.imwrite(name,img)
+            cv.imwrite(name, img)
         else:
             #print(np.array(grf['LF']).transpose()[i+start+1], np.array(angle['LF']).transpose()[i+start+1]*180/np.pi)
-            cv.imshow('img',img)
+            cv.imshow('img', img)
             cv.waitKey(pause)
     cv.destroyAllWindows()
-    
 
-def draw_legs_from_3d(data,exp_dir,data_2d,side='L',dir_name='traking_2d_from_3d_data',begin=0,end=0,saveimgs = False,pixelSize=[5.86e-3,5.86e-3,5.86e-3],pause=0):
+
+def draw_legs_from_3d(
+        data,
+        exp_dir,
+        data_2d,
+        side='L',
+        dir_name='traking_2d_from_3d_data',
+        begin=0,
+        end=0,
+        saveimgs=False,
+        pixelSize=[
+            5.86e-3,
+            5.86e-3,
+            5.86e-3],
+        pause=0):
     if side == 'L':
         cam_id = 1
     elif side == 'R':
         cam_id = 5
     elif side == 'F':
         cam_id = 3
-    
-    colors = {'RF_leg':(0,0,204),'RM_leg':(51,51,255),'RH_leg':(102,102,255),'LF_leg':(153,76,0),'LM_leg':(255,128,0),'LH_leg':(255,178,102)}
+
+    colors = {
+        'RF_leg': (
+            0, 0, 204), 'RM_leg': (
+            51, 51, 255), 'RH_leg': (
+                102, 102, 255), 'LF_leg': (
+                    153, 76, 0), 'LM_leg': (
+                        255, 128, 0), 'LH_leg': (
+                            255, 178, 102)}
 
     if end == 0:
         try:
             end = len(data['LF_leg']['Coxa']['raw_pos_aligned'])
-        except:
+        except BaseException:
             end = len(data['LF_leg']['Coxa']['raw_pos'])
-    for frame in range(begin,end):
-        print('\rFrame: ' + str(frame),end='')
+    for frame in range(begin, end):
+        print('\rFrame: ' + str(frame), end='')
         df3d_dir = exp_dir.find('df3d')
         folder = exp_dir[:df3d_dir]
-        img_name = folder + 'camera_' + str(cam_id) + '_img_' + '{:06}'.format(frame) + '.jpg'
+        img_name = folder + 'camera_' + \
+            str(cam_id) + '_img_' + '{:06}'.format(frame) + '.jpg'
         img = cv.imread(img_name)
         if side != 'F':
-            offset = np.mean(data_2d[cam_id][side+'M_leg']['Coxa'],axis=0)
+            offset = np.mean(data_2d[cam_id][side + 'M_leg']['Coxa'], axis=0)
         else:
-            offset_L = np.mean(data_2d[1]['LM_leg']['Coxa'],axis=0)[1]
-            offset_R = np.mean(data_2d[5]['RM_leg']['Coxa'],axis=0)[1]
+            offset_L = np.mean(data_2d[1]['LM_leg']['Coxa'], axis=0)[1]
+            offset_R = np.mean(data_2d[5]['RM_leg']['Coxa'], axis=0)[1]
         for leg, body_parts in data.items():
-            if side in leg[:2] or side =='F':#'L' or leg[0]=='R':
+            if side in leg[:2] or side == 'F':  # 'L' or leg[0]=='R':
                 color = colors[leg]
                 for segment, metrics in body_parts.items():
                     for metric, points in metrics.items():
                         if 'raw_pos' in metric and segment != 'Coxa':
                             if 'Femur' in segment:
-                                start = data[leg]['Coxa']['fixed_pos_aligned']/np.array(pixelSize)
-                                end = points[frame]/np.array(pixelSize)
+                                start = data[leg]['Coxa']['fixed_pos_aligned'] / \
+                                    np.array(pixelSize)
+                                end = points[frame] / np.array(pixelSize)
                             if 'Tibia' in segment:
-                                start = data[leg]['Femur'][metric][frame]/np.array(pixelSize)
-                                end = points[frame]/np.array(pixelSize)
+                                start = data[leg]['Femur'][metric][frame] / \
+                                    np.array(pixelSize)
+                                end = points[frame] / np.array(pixelSize)
                             if 'Tarsus' in segment:
-                                start = data[leg]['Tibia'][metric][frame]/np.array(pixelSize)
-                                end = points[frame]/np.array(pixelSize)
+                                start = data[leg]['Tibia'][metric][frame] / \
+                                    np.array(pixelSize)
+                                end = points[frame] / np.array(pixelSize)
                             if 'Claw' in segment:
-                                start = data[leg]['Tarsus'][metric][frame]/np.array(pixelSize)
-                                end = points[frame]/np.array(pixelSize)
+                                start = data[leg]['Tarsus'][metric][frame] / \
+                                    np.array(pixelSize)
+                                end = points[frame] / np.array(pixelSize)
                             if side == 'L':
-                                start_point = [int(start[0]),int(-start[2])]+offset
-                                end_point = [int(end[0]),int(-end[2])]+offset
+                                start_point = [
+                                    int(start[0]), int(-start[2])] + offset
+                                end_point = [
+                                    int(end[0]), int(-end[2])] + offset
                             elif side == 'R':
-                                start_point = [int(-start[0]),int(-start[2])]+offset
-                                end_point = [int(-end[0]),int(-end[2])]+offset
+                                start_point = [
+                                    int(-start[0]), int(-start[2])] + offset
+                                end_point = [
+                                    int(-end[0]), int(-end[2])] + offset
                             elif side == 'F':
                                 h, w, c = img.shape
                                 if 'L' in leg:
-                                    start_point = [int(start[1]+w/2),int(offset_L-start[2])]
-                                    end_point = [int(end[1]+w/2),int(offset_L-end[2])]
+                                    start_point = [
+                                        int(start[1] + w / 2), int(offset_L - start[2])]
+                                    end_point = [
+                                        int(end[1] + w / 2), int(offset_L - end[2])]
                                 if 'R' in leg:
-                                    start_point = [int(start[1]+w/2),int(offset_R-start[2])]
-                                    end_point = [int(end[1]+w/2),int(offset_R-end[2])]
-                            img = draw_lines(img,start_point,end_point,color=color)
+                                    start_point = [
+                                        int(start[1] + w / 2), int(offset_R - start[2])]
+                                    end_point = [
+                                        int(end[1] + w / 2), int(offset_R - end[2])]
+                            img = draw_lines(
+                                img, start_point, end_point, color=color)
         if saveimgs:
             file_name = exp_dir.split('/')[-1]
-            new_folder = 'results/'+file_name.replace('.pkl','/')+dir_name+'_'+side+'/'
+            new_folder = 'results/' + \
+                file_name.replace('.pkl', '/') + dir_name + '_' + side + '/'
             if not os.path.exists(new_folder):
                 os.makedirs(new_folder)
-            name = new_folder + 'camera_' + str(cam_id) + '_img_' + '{:06}'.format(frame) + '.jpg'
-            cv.imwrite(name,img)
-        cv.imshow('img',img)
+            name = new_folder + 'camera_' + \
+                str(cam_id) + '_img_' + '{:06}'.format(frame) + '.jpg'
+            cv.imwrite(name, img)
+        cv.imshow('img', img)
         cv.waitKey(pause)
     cv.destroyAllWindows()
 
-def draw_legs_from_2d(cams_info,data_2d,exp_dir, imgs_folder='', side='R',begin=0,end=0,saveimgs = False,pause=0,show_joints=True,dir_name='legsJoints'):
-    
+
+def draw_legs_from_2d(
+        cams_info,
+        data_2d,
+        exp_dir,
+        imgs_folder='',
+        side='R',
+        begin=0,
+        end=0,
+        saveimgs=False,
+        pause=0,
+        show_joints=True,
+        dir_name='legsJoints'):
+
     for key, info in cams_info.items():
-        r = R.from_dcm(info['R']) 
+        r = R.from_dcm(info['R'])
         th = r.as_euler('zyx', degrees=True)[1]
-        if 90-th<15 and side=='L':
-            data = data_2d[key-1]
-            cam_id = key-1 
-        elif 90-th>165 and side=='R':
-            data = data_2d[key-1]
-            cam_id = key-1
-        #elif abs(th)+1 < 10:
+        if 90 - th < 15 and side == 'L':
+            data = data_2d[key - 1]
+            cam_id = key - 1
+        elif 90 - th > 165 and side == 'R':
+            data = data_2d[key - 1]
+            cam_id = key - 1
+        # elif abs(th)+1 < 10:
         #    front_view['F_points2d'] = data_2d[key-1]
         #    front_view['cam_id'] = key-1
-    
-    colors = {'RF_leg':(0,0,204),'RM_leg':(51,51,255),'RH_leg':(102,102,255),'LF_leg':(153,76,0),'LM_leg':(255,128,0),'LH_leg':(255,178,102)}
-    
+
+    colors = {
+        'RF_leg': (
+            0, 0, 204), 'RM_leg': (
+            51, 51, 255), 'RH_leg': (
+                102, 102, 255), 'LF_leg': (
+                    153, 76, 0), 'LM_leg': (
+                        255, 128, 0), 'LH_leg': (
+                            255, 178, 102)}
+
     if end == 0:
         end = len(data['LF_leg']['Coxa'])
-        
+
     if imgs_folder == '':
         df3d_dir = exp_dir.find('df3d')
         folder = exp_dir[:df3d_dir]
     else:
         folder = os.path.join(imgs_folder)
-    
-    for frame in range(begin,end):
-        img_name = folder + 'camera_' + str(cam_id) + '_img_' + '{:06}'.format(frame) + '.jpg'
+
+    for frame in range(begin, end):
+        img_name = folder + 'camera_' + \
+            str(cam_id) + '_img_' + '{:06}'.format(frame) + '.jpg'
         img = cv.imread(img_name)
         for leg, body_parts in data.items():
-            if leg[0] == 'L' or leg[0]=='R':
+            if leg[0] == 'L' or leg[0] == 'R':
                 color = colors[leg]
                 for segment, points in body_parts.items():
                     if segment != 'Coxa':
@@ -1244,101 +1586,138 @@ def draw_legs_from_2d(cams_info,data_2d,exp_dir, imgs_folder='', side='R',begin=
                             end_point = points[frame]
 
                         if show_joints:
-                            img = draw_joints(img, start_point,color=color)
+                            img = draw_joints(img, start_point, color=color)
                             if 'Claw' in segment:
-                                img = draw_joints(img, end_point,color=color)
-                        img = draw_lines(img,start_point,end_point,color=color)
-                        
+                                img = draw_joints(img, end_point, color=color)
+                        img = draw_lines(
+                            img, start_point, end_point, color=color)
+
         if saveimgs:
             file_name = exp_dir.split('/')[-1]
-            new_folder = 'results/'+file_name.replace('.pkl','/')+'tracking_2d_'+dir_name+'/'
+            new_folder = 'results/' + \
+                file_name.replace('.pkl', '/') + 'tracking_2d_' + dir_name + '/'
             if not os.path.exists(new_folder):
                 os.makedirs(new_folder)
-            name = new_folder + 'camera_' + str(cam_id) + '_img_' + '{:06}'.format(frame) + '.jpg'
-            cv.imwrite(name,img)
+            name = new_folder + 'camera_' + \
+                str(cam_id) + '_img_' + '{:06}'.format(frame) + '.jpg'
+            cv.imwrite(name, img)
         else:
-            cv.imshow('img',img)
+            cv.imshow('img', img)
             cv.waitKey(pause)
     cv.destroyAllWindows()
 
-def draw_joints(img,start,radius=8,color=(255,0,0),thickness=-1):
+
+def draw_joints(img, start, radius=8, color=(255, 0, 0), thickness=-1):
     coords = np.array(start).astype(int)
-    joint = (coords[0],coords[1])
+    joint = (coords[0], coords[1])
 
     cv.circle(img, joint, radius, color, thickness)
 
     return img
 
-def draw_lines(img, start, end, color = (255, 0, 0), thickness=5, arrowHead=False):
+
+def draw_lines(
+        img,
+        start,
+        end,
+        color=(
+            255,
+            0,
+            0),
+    thickness=5,
+        arrowHead=False):
     coords_prev = np.array(start).astype(int)
     coords_next = np.array(end).astype(int)
 
-    start_point = (coords_prev[0],coords_prev[1])
-    end_point = (coords_next[0],coords_next[1]) 
+    start_point = (coords_prev[0], coords_prev[1])
+    end_point = (coords_next[0], coords_next[1])
 
     if arrowHead:
-        if np.linalg.norm(coords_prev-coords_next)>100:
+        if np.linalg.norm(coords_prev - coords_next) > 100:
             tL = 0.25
         else:
             tL = 0.5
-        cv.arrowedLine(img, start_point, end_point, color, thickness, tipLength = tL)
+        cv.arrowedLine(
+            img,
+            start_point,
+            end_point,
+            color,
+            thickness,
+            tipLength=tL)
     else:
-        cv.line(img, start_point, end_point, color, thickness) 
+        cv.line(img, start_point, end_point, color, thickness)
 
     return img
 
-def plot_SG_angles(angles,degrees=True):
+
+def plot_SG_angles(angles, degrees=True):
     frames, segments = angles.shape
-    fig_top = plt.figure()  
+    fig_top = plt.figure()
     ax_2d = plt.axes()
-    labels = ['pitch','yaw','roll','th_fe','th_ti','th_ta']
+    labels = ['pitch', 'yaw', 'roll', 'th_fe', 'th_ti', 'th_ta']
     for i in range(6):
-        #if degrees:
+        # if degrees:
         #    angles[:,i] = np.array(angles[:,1])*180/np.pi
-        ax_2d.plot(angles[:,i], label=labels[i])
+        ax_2d.plot(angles[:, i], label=labels[i])
 
     ax_2d.legend()
     ax_2d.set_xlabel('time')
     ax_2d.set_ylabel('deg')
     ax_2d.grid(True)
-    
+
     plt.show()
 
-def plot_3d_and_2d(data, plane='xz', begin=0,end=0,metric = 'raw_pos_aligned', savePlot = False, pause=False):
-    colors = {'RF':(1,0,0),'RM':(0,1,0),'RH':(0,0,1),'LF':(1,1,0),'LM':(1,0,1),'LH':(0,1,1),'He':(1,1,1)}
+
+def plot_3d_and_2d(
+        data,
+        plane='xz',
+        begin=0,
+        end=0,
+        metric='raw_pos_aligned',
+        savePlot=False,
+        pause=False):
+    colors = {
+        'RF': (
+            1, 0, 0), 'RM': (
+            0, 1, 0), 'RH': (
+                0, 0, 1), 'LF': (
+                    1, 1, 0), 'LM': (
+                        1, 0, 1), 'LH': (
+                            0, 1, 1), 'He': (
+                                1, 1, 1)}
     if end == 0:
         end = len(data['LF_leg']['Coxa'][metric])
     fig_3d = plt.figure()
     if plane is not '':
         view_2d = plt.figure()
-    for frame in range(begin,end):
-        print('\rFrame: '+str(frame),end='')
+    for frame in range(begin, end):
+        print('\rFrame: ' + str(frame), end='')
         ax_3d = fig_3d.add_subplot(111, projection='3d')
-        
+
         if plane is not '':
             ax_2d = plt.axes()
-            
+
         for segment, landmark in data.items():
-            #if 'L' in segment or 'R' in segment:
-                x=[]
-                y=[]
-                z=[]
-                for key, val in landmark.items():
-                    try:
-                        x.append(val[metric][frame][0])
-                        y.append(val[metric][frame][1])
-                        z.append(val[metric][frame][2])
-                    except:
-                        x.append(val[frame][0])
-                        y.append(val[frame][1])
-                        z.append(val[frame][2])
-                ax_3d.plot(x, y, z, '-o', label=segment, color = colors[segment[:2]])
-                if plane == 'xy':
-                    ax_2d.plot(x, y, '--x', label=segment)
-                if plane == 'xz':
-                    ax_2d.plot(x, z, '--x', label=segment)
-                if plane == 'yz':
-                    ax_2d.plot(y, z, '--x', label=segment)
+            # if 'L' in segment or 'R' in segment:
+            x = []
+            y = []
+            z = []
+            for key, val in landmark.items():
+                try:
+                    x.append(val[metric][frame][0])
+                    y.append(val[metric][frame][1])
+                    z.append(val[metric][frame][2])
+                except BaseException:
+                    x.append(val[frame][0])
+                    y.append(val[frame][1])
+                    z.append(val[frame][2])
+            ax_3d.plot(x, y, z, '-o', label=segment, color=colors[segment[:2]])
+            if plane == 'xy':
+                ax_2d.plot(x, y, '--x', label=segment)
+            if plane == 'xz':
+                ax_2d.plot(x, z, '--x', label=segment)
+            if plane == 'yz':
+                ax_2d.plot(y, z, '--x', label=segment)
 
         ax_3d.legend(loc='upper left')
         ax_3d.set_title('Tracking 3D')
@@ -1354,21 +1733,21 @@ def plot_3d_and_2d(data, plane='xz', begin=0,end=0,metric = 'raw_pos_aligned', s
             folder = 'results/tracking_3d_leftside/'
             if not os.path.exists(folder):
                 os.makedirs(folder)
-            figName = folder + 'pos_3d_frame_'+str(frame)+'.png'
+            figName = folder + 'pos_3d_frame_' + str(frame) + '.png'
             fig_3d.savefig(figName)
 
         if plane is not '':
             ax_2d.legend()
-            ax_2d.set_xlabel(plane[0]+' (mm)')
-            ax_2d.set_ylabel(plane[1]+' (mm)')
-            ax_2d.set_xlim(-1.5,1.5)
-            ax_2d.set_ylim(-1.5,1.5)
+            ax_2d.set_xlabel(plane[0] + ' (mm)')
+            ax_2d.set_ylabel(plane[1] + ' (mm)')
+            ax_2d.set_xlim(-1.5, 1.5)
+            ax_2d.set_ylim(-1.5, 1.5)
             ax_2d.grid(True)
 
         if pause:
             plt.show()
         else:
-            #plt.show(block=False)
+            # plt.show(block=False)
             plt.draw()
             plt.pause(0.001)
         fig_3d.clf()
@@ -1377,16 +1756,17 @@ def plot_3d_and_2d(data, plane='xz', begin=0,end=0,metric = 'raw_pos_aligned', s
 
     plt.close()
 
-def plot_fixed_coxa(aligned_dict,plane='xy'):
+
+def plot_fixed_coxa(aligned_dict, plane='xy'):
     metric = 'fixed_pos_aligned'
     fig_3d = plt.figure()
     fig_top = plt.figure()
     ax_3d = fig_3d.add_subplot(111, projection='3d')
     ax_2d = plt.axes()
     for leg, joints in aligned_dict.items():
-        x=[]
-        y=[]
-        z=[]
+        x = []
+        y = []
+        z = []
         for joint, data in joints.items():
             if 'Coxa' in joint:
                 x.append(data[metric][0])
@@ -1407,127 +1787,249 @@ def plot_fixed_coxa(aligned_dict,plane='xy'):
     ax_3d.grid(True)
 
     ax_2d.legend()
-    ax_2d.set_xlabel(plane[0]+' (mm)')
-    ax_2d.set_ylabel(plane[1]+' (mm)')
+    ax_2d.set_xlabel(plane[0] + ' (mm)')
+    ax_2d.set_ylabel(plane[1] + ' (mm)')
     ax_2d.grid(True)
-    
+
     plt.show()
 
 
-def plot_RoM_distance(data_dict, axis, savePlot=False,gen='fly'):
-    #names = ['RF_leg','LF_leg','RM_leg','LM_leg','RH_leg','LH_leg'] 
-    plt.figure() 
-    for name, leg in data_dict.items(): 
-        x_amp = [] 
-        y_amp = [] 
-        z_amp = [] 
-        j = list(leg.keys()) 
-        for k, joints in leg.items(): 
-            #plt.figure()
-            try: 
-                x_pos = joints['raw_pos_aligned'].transpose()[0] 
-                y_pos = joints['raw_pos_aligned'].transpose()[1] 
+def plot_RoM_distance(data_dict, axis, savePlot=False, gen='fly'):
+    #names = ['RF_leg','LF_leg','RM_leg','LM_leg','RH_leg','LH_leg']
+    plt.figure()
+    for name, leg in data_dict.items():
+        x_amp = []
+        y_amp = []
+        z_amp = []
+        j = list(leg.keys())
+        for k, joints in leg.items():
+            # plt.figure()
+            try:
+                x_pos = joints['raw_pos_aligned'].transpose()[0]
+                y_pos = joints['raw_pos_aligned'].transpose()[1]
                 z_pos = joints['raw_pos_aligned'].transpose()[2]
-            except:
-                x_pos = joints.transpose()[0] 
-                y_pos = joints.transpose()[1] 
+            except BaseException:
+                x_pos = joints.transpose()[0]
+                y_pos = joints.transpose()[1]
                 z_pos = joints.transpose()[2]
-            x_amp.append(np.max(x_pos)-np.min(x_pos)) 
-            y_amp.append(np.max(y_pos)-np.min(y_pos)) 
-            z_amp.append(np.max(z_pos)-np.min(z_pos))         
-            #print(name + ': ' + k) 
-            #print('X(amp,max,min): ', np.max(x_pos)-np.min(x_pos), np.max(x_pos), np.min(x_pos)) 
+            x_amp.append(np.max(x_pos) - np.min(x_pos))
+            y_amp.append(np.max(y_pos) - np.min(y_pos))
+            z_amp.append(np.max(z_pos) - np.min(z_pos))
+            #print(name + ': ' + k)
+            #print('X(amp,max,min): ', np.max(x_pos)-np.min(x_pos), np.max(x_pos), np.min(x_pos))
             #print('Y(amp,max,min): ', np.max(y_pos)-np.min(y_pos), np.max(y_pos), np.min(y_pos))
             #print('Z(amp,max,min): ', np.max(z_pos)-np.min(z_pos), np.max(z_pos), np.min(z_pos))
         if axis == 'x':
-            plt.plot(j,x_amp,'--o',label=name)
+            plt.plot(j, x_amp, '--o', label=name)
         if axis == 'y':
-            plt.plot(j,y_amp,'--o',label=name)
+            plt.plot(j, y_amp, '--o', label=name)
         if axis == 'z':
-            plt.plot(j,z_amp,'--o',label=name)
-     
-    plt.title('Range of motion: ' + axis + '-axis') 
-    plt.xlabel('Joints') 
+            plt.plot(j, z_amp, '--o', label=name)
+
+    plt.title('Range of motion: ' + axis + '-axis')
+    plt.xlabel('Joints')
     plt.ylabel('Distance (mm)')
     plt.ylim(-0.1, 4.1)
-    plt.legend(loc='upper left') 
+    plt.legend(loc='upper left')
     plt.grid()
     if savePlot:
-        figName = gen + '_rom_distance_'+axis+'_axis.png'
+        figName = gen + '_rom_distance_' + axis + '_axis.png'
         plt.savefig(figName)
     plt.show()
 
-def plot_pos_series(data_dict, legs, joints, savePlot=False, gen = 'fly'):
-    for name in legs: 
-        x_amp = [] 
-        y_amp = [] 
-        z_amp = [] 
-        j = list(data_dict[name].keys()) 
+
+def plot_pos_series(data_dict, legs, joints, savePlot=False, gen='fly'):
+    for name in legs:
+        x_amp = []
+        y_amp = []
+        z_amp = []
+        j = list(data_dict[name].keys())
         for k, joint in data_dict[name].items():
             if k in joints:
                 plt.figure()
-                try: 
-                    x_pos = joint['raw_pos_aligned'].transpose()[0] 
-                    y_pos = joint['raw_pos_aligned'].transpose()[1] 
+                try:
+                    x_pos = joint['raw_pos_aligned'].transpose()[0]
+                    y_pos = joint['raw_pos_aligned'].transpose()[1]
                     z_pos = joint['raw_pos_aligned'].transpose()[2]
-                except:
-                    x_pos = joint.transpose()[0] 
-                    y_pos = joint.transpose()[1] 
+                except BaseException:
+                    x_pos = joint.transpose()[0]
+                    y_pos = joint.transpose()[1]
                     z_pos = joint.transpose()[2]
-                time = np.arange(len(x_pos))/100
-                plt.plot(time,x_pos,label='x') 
-                plt.plot(time,y_pos,label='y') 
-                plt.plot(time,z_pos,label='z')     
-                plt.title(k + ' ' + name + ': 3D position') 
-                plt.xlabel('Time (s)') 
+                time = np.arange(len(x_pos)) / 100
+                plt.plot(time, x_pos, label='x')
+                plt.plot(time, y_pos, label='y')
+                plt.plot(time, z_pos, label='z')
+                plt.title(k + ' ' + name + ': 3D position')
+                plt.xlabel('Time (s)')
                 plt.ylabel('Distance (mm)')
-                plt.ylim(-3, 4) 
-                plt.legend() 
+                plt.ylim(-3, 4)
+                plt.legend()
                 plt.grid()
                 if savePlot:
-                    figName = gen+'_' + name+'_'+k+'_pos.png'
+                    figName = gen + '_' + name + '_' + k + '_pos.png'
                     plt.savefig(figName)
                 plt.show()
 
 
-def plot_legs_from_angles(angles,data_dict,exp_dir,begin=0,end=0,plane='xz',saveImgs = False, dir_name='km', extraDOF = {}, ik_angles = False, pause = False,lim_axes=True):
+def plot_legs_from_angles(
+        angles,
+        data_dict,
+        exp_dir,
+        begin=0,
+        end=0,
+        plane='xz',
+        saveImgs=False,
+        dir_name='km',
+        extraDOF={},
+        ik_angles=False,
+        pause=False,
+        lim_axes=True):
 
     #colors_real= {'LF_leg':(1,0,0),'LM_leg':(0,1,0),'LH_leg':(0,0,1),'RF_leg':(1,1,0),'RM_leg':(1,0,1),'RH_leg':(0,1,1)}
     #colors = {'LF_leg':(1,0.5,0.5),'LM_leg':(0.5,1,0.5),'LH_leg':(0.5,0.5,1),'RF_leg':(1,1,0.5),'RM_leg':(1,0.5,1),'RH_leg':(0.5,1,1)}
 
-    colors = {'RF_leg':(204/255,0,0),'RM_leg':(1,51/255,51/255),'RH_leg':(1,102/255,102/255),'LF_leg':(0,76/255,153/255),'LM_leg':(0,0.5,1),'LH_leg':(102/255,178/255,1)}
+    colors = {
+        'RF_leg': (
+            204 / 255,
+            0,
+            0),
+        'RM_leg': (
+            1,
+            51 / 255,
+            51 / 255),
+        'RH_leg': (
+            1,
+            102 / 255,
+            102 / 255),
+        'LF_leg': (
+            0,
+            76 / 255,
+            153 / 255),
+        'LM_leg': (
+            0,
+            0.5,
+            1),
+        'LH_leg': (
+            102 / 255,
+            178 / 255,
+            1)}
 
-    
-    legend_3D = [(Line2D([0], [0], marker='o', ms=6, ls='-', lw=2, color=colors['LF_leg']),
-                  Line2D([0], [0], marker='o', ms=6, ls='-', lw=2, color=colors['RF_leg'])),
-                 (Line2D([0], [0], marker='o', ms=6, ls='-', lw=2, color=colors['LM_leg']),
-                  Line2D([0], [0], marker='o', ms=6, ls='-', lw=2, color=colors['RM_leg'])),
-                 (Line2D([0], [0], marker='o', ms=6, ls='-', lw=2, color=colors['LH_leg']),
-                  Line2D([0], [0], marker='o', ms=6, ls='-', lw=2, color=colors['RH_leg']))]
+    legend_3D = [
+        (Line2D(
+            [0],
+            [0],
+            marker='o',
+            ms=6,
+            ls='-',
+            lw=2,
+            color=colors['LF_leg']),
+            Line2D(
+            [0],
+            [0],
+            marker='o',
+            ms=6,
+            ls='-',
+            lw=2,
+            color=colors['RF_leg'])),
+        (Line2D(
+            [0],
+            [0],
+            marker='o',
+            ms=6,
+            ls='-',
+            lw=2,
+            color=colors['LM_leg']),
+         Line2D(
+            [0],
+            [0],
+            marker='o',
+            ms=6,
+            ls='-',
+            lw=2,
+            color=colors['RM_leg'])),
+        (Line2D(
+            [0],
+            [0],
+            marker='o',
+            ms=6,
+            ls='-',
+            lw=2,
+            color=colors['LH_leg']),
+         Line2D(
+            [0],
+            [0],
+            marker='o',
+            ms=6,
+            ls='-',
+            lw=2,
+            color=colors['RH_leg']))]
 
-    legend_FK = [(Line2D([0], [0], marker='x', ms=6, ls='--', lw=2, color=colors['LF_leg']),
-                  Line2D([0], [0], marker='x', ms=6, ls='--', lw=2, color=colors['RF_leg'])),
-                 (Line2D([0], [0], marker='x', ms=6, ls='--', lw=2, color=colors['LM_leg']),
-                  Line2D([0], [0], marker='x', ms=6, ls='--', lw=2, color=colors['RM_leg'])),
-                 (Line2D([0], [0], marker='x', ms=6, ls='--', lw=2, color=colors['LH_leg']),
-                  Line2D([0], [0], marker='x', ms=6, ls='--', lw=2, color=colors['RH_leg']))]
+    legend_FK = [
+        (Line2D(
+            [0],
+            [0],
+            marker='x',
+            ms=6,
+            ls='--',
+            lw=2,
+            color=colors['LF_leg']),
+            Line2D(
+            [0],
+            [0],
+            marker='x',
+            ms=6,
+            ls='--',
+            lw=2,
+            color=colors['RF_leg'])),
+        (Line2D(
+            [0],
+            [0],
+            marker='x',
+            ms=6,
+            ls='--',
+            lw=2,
+            color=colors['LM_leg']),
+         Line2D(
+            [0],
+            [0],
+            marker='x',
+            ms=6,
+            ls='--',
+            lw=2,
+            color=colors['RM_leg'])),
+        (Line2D(
+            [0],
+            [0],
+            marker='x',
+            ms=6,
+            ls='--',
+            lw=2,
+            color=colors['LH_leg']),
+         Line2D(
+            [0],
+            [0],
+            marker='x',
+            ms=6,
+            ls='--',
+            lw=2,
+            color=colors['RH_leg']))]
 
     fig_3d = plt.figure()
     if plane is not '':
         view_2d = plt.figure()
-    
+
     if end == 0:
         end = len(angles['RF_leg']['ThC_yaw'])
 
-    order = ['LH_leg','LM_leg','LF_leg','RH_leg','RM_leg','RF_leg']
-    angles_rev = {leg:angles[leg] for leg in order}
+    order = ['LH_leg', 'LM_leg', 'LF_leg', 'RH_leg', 'RM_leg', 'RF_leg']
+    angles_rev = {leg: angles[leg] for leg in order}
 
-    lim_x = (-2.5,1.5)
-    lim_y = (-1.2,2)
-    lim_z = (-1.5,0.1)
-    
+    lim_x = (-2.5, 1.5)
+    lim_y = (-1.2, 2)
+    lim_z = (-1.5, 0.1)
+
     for frame in range(begin, end):
-        print('\rFrame: '+str(frame),end='')
+        print('\rFrame: ' + str(frame), end='')
         ax_3d = fig_3d.add_subplot(111, projection='3d')
         ax_3d.set_xlabel('mm')
         ax_3d.set_ylabel('mm')
@@ -1557,69 +2059,112 @@ def plot_legs_from_angles(angles,data_dict,exp_dir,begin=0,end=0,plane='xz',save
             for name_DOF, dict_DOF in extraDOF.items():
                 try:
                     extraDOF_vals[name_DOF] = dict_DOF[name][name_DOF][frame]
-                except:
+                except BaseException:
                     extraDOF_vals[name_DOF] = dict_DOF[name][name_DOF]['best_angle'][frame]
             if ik_angles:
                 pos_3d = fk_from_ik(leg, name, data_dict, frame).transpose()
             else:
-                pos_3d = utils_angles.calculate_forward_kinematics(name, frame, leg, data_dict, extraDOF=extraDOF_vals).transpose()
+                pos_3d = utils_angles.calculate_forward_kinematics(
+                    name, frame, leg, data_dict, extraDOF=extraDOF_vals).transpose()
 
-                      
             x = pos_3d[0]
             y = pos_3d[1]
             z = pos_3d[2]
-            ax_3d.plot(x, y, z, '--x', label=name, color = colors[name])            
+            ax_3d.plot(x, y, z, '--x', label=name, color=colors[name])
 
-            real_pos_3d = np.array([coxa_pos,real_pos_femur,real_pos_tibia,real_pos_tarsus,real_pos_claw]).transpose()
+            real_pos_3d = np.array([coxa_pos,
+                                    real_pos_femur,
+                                    real_pos_tibia,
+                                    real_pos_tarsus,
+                                    real_pos_claw]).transpose()
             real_x = real_pos_3d[0]
             real_y = real_pos_3d[1]
             real_z = real_pos_3d[2]
-            ax_3d.plot(real_x, real_y, real_z, '-o', label=name+'_real', color = colors[name])
+            ax_3d.plot(
+                real_x,
+                real_y,
+                real_z,
+                '-o',
+                label=name +
+                '_real',
+                color=colors[name])
 
             if plane == 'xy':
                 if lim_axes:
                     ax_2d.set_xlim(lim_x)
                     ax_2d.set_ylim(lim_y)
-                ax_2d.plot(real_x, real_y, '-o', label=name+'_real', color = colors[name])
-                ax_2d.plot(x, y, '--x', label=name, color = colors[name])
+                ax_2d.plot(
+                    real_x,
+                    real_y,
+                    '-o',
+                    label=name +
+                    '_real',
+                    color=colors[name])
+                ax_2d.plot(x, y, '--x', label=name, color=colors[name])
             if plane == 'xz':
                 if lim_axes:
                     ax_2d.set_xlim(lim_x)
                     ax_2d.set_ylim(lim_z)
-                ax_2d.plot(real_x, real_z, '-o', label=name+'_real', color = colors[name])
-                ax_2d.plot(x, z, '--x', label=name, color = colors[name])
+                ax_2d.plot(
+                    real_x,
+                    real_z,
+                    '-o',
+                    label=name +
+                    '_real',
+                    color=colors[name])
+                ax_2d.plot(x, z, '--x', label=name, color=colors[name])
             if plane == 'yz':
                 if lim_axes:
                     ax_2d.set_xlim(lim_y)
                     ax_2d.set_ylim(lim_z)
-                ax_2d.plot(real_y, real_z, '-o', label=name+'_real', color = colors[name])
-                ax_2d.plot(y, z, '--x', label=name, color = colors[name])
-            
+                ax_2d.plot(
+                    real_y,
+                    real_z,
+                    '-o',
+                    label=name +
+                    '_real',
+                    color=colors[name])
+                ax_2d.plot(y, z, '--x', label=name, color=colors[name])
+
         if saveImgs:
             file_name = exp_dir.split('/')[-1]
-            new_folder_3d = 'results/'+file_name.replace('.pkl','/')+dir_name+'_3d/'
-            new_folder_2d = 'results/'+file_name.replace('.pkl','/')+dir_name+'_'+plane+'/'
+            new_folder_3d = 'results/' + \
+                file_name.replace('.pkl', '/') + dir_name + '_3d/'
+            new_folder_2d = 'results/' + \
+                file_name.replace('.pkl', '/') + dir_name + '_' + plane + '/'
             if not os.path.exists(new_folder_3d):
                 os.makedirs(new_folder_3d)
             if plane is not '':
                 if not os.path.exists(new_folder_2d):
                     os.makedirs(new_folder_2d)
-            name_3d = new_folder_3d + 'km_3d' + '_img_' + '{:06}'.format(frame) + '.jpg'
-            name_2d = new_folder_2d + 'km_' + plane + '_img_' + '{:06}'.format(frame) + '.jpg'
-            
+            name_3d = new_folder_3d + 'km_3d' + \
+                '_img_' + '{:06}'.format(frame) + '.jpg'
+            name_2d = new_folder_2d + 'km_' + plane + \
+                '_img_' + '{:06}'.format(frame) + '.jpg'
+
             w_img = int(12)
-            h_img = int(w_img*3/4)
+            h_img = int(w_img * 3 / 4)
             fig_3d.set_size_inches(w_img, h_img)
 
-            first_legend = ax_3d.legend(legend_3D,['Prothoracic legs','Mesothoracic legs','Metathoracic legs'], numpoints=1, handler_map={tuple: HandlerTuple(ndivide=None)},handlelength=6,loc='lower left',title='Pose from 3D tracking',bbox_to_anchor=(0, -0.03))
+            first_legend = ax_3d.legend(
+                legend_3D, [
+                    'Prothoracic legs', 'Mesothoracic legs', 'Metathoracic legs'], numpoints=1, handler_map={
+                    tuple: HandlerTuple(
+                        ndivide=None)}, handlelength=6, loc='lower left', title='Pose from 3D tracking', bbox_to_anchor=(
+                    0, -0.03))
 
             ax_legend = plt.gca().add_artist(first_legend)
 
-            ax_3d.legend(legend_FK,['Prothoracic legs','Mesothoracic legs','Metathoracic legs'], numpoints=1, handler_map={tuple: HandlerTuple(ndivide=None)},handlelength=6,loc='lower right',title='Pose from forward kinematics',bbox_to_anchor=(1.03, -0.03))
+            ax_3d.legend(
+                legend_FK, [
+                    'Prothoracic legs', 'Mesothoracic legs', 'Metathoracic legs'], numpoints=1, handler_map={
+                    tuple: HandlerTuple(
+                        ndivide=None)}, handlelength=6, loc='lower right', title='Pose from forward kinematics', bbox_to_anchor=(
+                    1.03, -0.03))
 
             #ax_3d.legend(handles=legend_elements, loc='upper right',ncol=2,handletextpad=0.1)
-            
-            fig_3d.savefig(name_3d,dpi=300,bbox_inches='tight')
+
+            fig_3d.savefig(name_3d, dpi=300, bbox_inches='tight')
             if plane is not '':
                 view_2d.savefig(name_2d)
 
@@ -1630,7 +2175,7 @@ def plot_legs_from_angles(angles,data_dict,exp_dir,begin=0,end=0,plane='xz',save
             if pause:
                 plt.show()
             else:
-                #plt.show(block=False)
+                # plt.show(block=False)
                 plt.draw()
                 plt.pause(0.001)
 
@@ -1641,94 +2186,105 @@ def plot_legs_from_angles(angles,data_dict,exp_dir,begin=0,end=0,plane='xz',save
     plt.close()
 
 
-def plot_correlation_matrix(angles,roll_tr,align):
+def plot_correlation_matrix(angles, roll_tr, align):
     for name, leg in angles.items():
         claw_h = align[name]['Claw']['raw_pos_aligned'].transpose()[2]
         tarsus_h = align[name]['Tarsus']['raw_pos_aligned'].transpose()[2]
         tibia_h = align[name]['Tibia']['raw_pos_aligned'].transpose()[2]
-        
-        r = np.corrcoef([roll_tr[name]['best_roll'], claw_h, tarsus_h, tibia_h, leg['yaw'], leg['pitch'], leg['roll'], leg['th_fe'], leg['th_ti'], leg['th_ta']])
 
-        labels = ['roll_tr']+list(leg.keys())
-        
-        plot_heatmap(r,labels,name)
+        r = np.corrcoef([roll_tr[name]['best_roll'],
+                         claw_h,
+                         tarsus_h,
+                         tibia_h,
+                         leg['yaw'],
+                         leg['pitch'],
+                         leg['roll'],
+                         leg['th_fe'],
+                         leg['th_ti'],
+                         leg['th_ta']])
 
-def plot_heatmap(corr, labels,title):
+        labels = ['roll_tr'] + list(leg.keys())
 
-    ax = sns.heatmap( 
-        corr,  
-        #vmin=-1, vmax=1, center=0, 
-        annot=True, 
-        xticklabels = labels,
-        yticklabels = labels, 
-        #cmap = 'seismic' 
-        )
+        plot_heatmap(r, labels, name)
+
+
+def plot_heatmap(corr, labels, title):
+
+    ax = sns.heatmap(
+        corr,
+        # vmin=-1, vmax=1, center=0,
+        annot=True,
+        xticklabels=labels,
+        yticklabels=labels,
+        #cmap = 'seismic'
+    )
     plt.title(title)
     plt.show()
 
-def calculate_svm_from_angles(angles, diff,align):
-  
-    #angles=np.load('angles.pkl',allow_pickle=True)  
-    #diff=np.load('diff_general.pkl',allow_pickle=True)  
-        
-    #name = 'LF_leg' 
-    #name2 = 'RF_leg' 
-    mat=np.zeros((len(angles.keys()),len(angles.keys()))) 
-    
-    for i, (name, leg) in enumerate(angles.items()):   
-        claw_h = align[name]['Claw']['raw_pos_aligned'].transpose()[2]  
-        tarsus_h = align[name]['Tarsus']['raw_pos_aligned'].transpose()[2] 
-    
-        tibia_h = align[name]['Tibia']['raw_pos_aligned'].transpose()[2]  
-        yaw = angles[name]['yaw'] 
-        pitch = angles[name]['pitch'] 
-        roll = angles[name]['roll'] 
-        th_fe = angles[name]['th_fe'] 
-        th_ti = angles[name]['th_ti'] 
-        th_ta = angles[name]['th_ta'] 
-        X = np.array([claw_h, tarsus_h, tibia_h, roll, th_fe]) 
-        y = np.array(diff[name]['best_roll']) 
-        clf = svm.SVR() 
-        clf.fit(X.T,y) 
-     
-        for j, (name2, leg) in enumerate(angles.items()):  
-        
+
+def calculate_svm_from_angles(angles, diff, align):
+
+    # angles=np.load('angles.pkl',allow_pickle=True)
+    # diff=np.load('diff_general.pkl',allow_pickle=True)
+
+    #name = 'LF_leg'
+    #name2 = 'RF_leg'
+    mat = np.zeros((len(angles.keys()), len(angles.keys())))
+
+    for i, (name, leg) in enumerate(angles.items()):
+        claw_h = align[name]['Claw']['raw_pos_aligned'].transpose()[2]
+        tarsus_h = align[name]['Tarsus']['raw_pos_aligned'].transpose()[2]
+
+        tibia_h = align[name]['Tibia']['raw_pos_aligned'].transpose()[2]
+        yaw = angles[name]['yaw']
+        pitch = angles[name]['pitch']
+        roll = angles[name]['roll']
+        th_fe = angles[name]['th_fe']
+        th_ti = angles[name]['th_ti']
+        th_ta = angles[name]['th_ta']
+        X = np.array([claw_h, tarsus_h, tibia_h, roll, th_fe])
+        y = np.array(diff[name]['best_roll'])
+        clf = svm.SVR()
+        clf.fit(X.T, y)
+
+        for j, (name2, leg) in enumerate(angles.items()):
+
             claw_h = align[name2]['Claw']['raw_pos_aligned'].transpose()[2]
-      
+
             tarsus_h = align[name2]['Tarsus']['raw_pos_aligned'].transpose()[2]
-            tibia_h = align[name2]['Tibia']['raw_pos_aligned'].transpose()[2]   
-            yaw = angles[name2]['yaw']  
-            pitch = angles[name2]['pitch']  
-            roll = angles[name2]['roll']  
-            th_fe = angles[name2]['th_fe']  
-            th_ti = angles[name2]['th_ti']  
-            th_ta = angles[name2]['th_ta']  
-            X2 = np.array([claw_h, tarsus_h, tibia_h, roll, th_fe])  
-            y_real = np.array(diff[name2]['best_roll']) 
-            
-            y_pred = clf.predict(X2.T) 
-            mse = mean_squared_error(y_real,y_pred) 
-            rmse = np.sqrt(mse)*180/np.pi 
-            mat[i][j] = rmse 
-            print(name + ' to ' + name2, rmse) 
+            tibia_h = align[name2]['Tibia']['raw_pos_aligned'].transpose()[2]
+            yaw = angles[name2]['yaw']
+            pitch = angles[name2]['pitch']
+            roll = angles[name2]['roll']
+            th_fe = angles[name2]['th_fe']
+            th_ti = angles[name2]['th_ti']
+            th_ta = angles[name2]['th_ta']
+            X2 = np.array([claw_h, tarsus_h, tibia_h, roll, th_fe])
+            y_real = np.array(diff[name2]['best_roll'])
+
+            y_pred = clf.predict(X2.T)
+            mse = mean_squared_error(y_real, y_pred)
+            rmse = np.sqrt(mse) * 180 / np.pi
+            mat[i][j] = rmse
+            print(name + ' to ' + name2, rmse)
         print()
 
-    plot_heatmap(mat,list(angles.keys()),'RMSE')
+    plot_heatmap(mat, list(angles.keys()), 'RMSE')
+
 
 def plot_error(
     errors_dict,
     path_results='',
-    split = True,
-    BL = 2.88,
-    begin = 0,
-    end = 0,
-    time_step = 0.01,
+    split=True,
+    BL=2.88,
+    begin=0,
+    end=0,
+    time_step=0.01,
     joint='all',
     save_results=False
-    ):
-
+):
     """ Plots errors measured from kinematic replay using different DoFs.
-    
+
     Parameters
     ----------
     errors_dict: <dict>
@@ -1747,15 +2303,24 @@ def plot_error(
         Data time step.
     joint: <str>
         Joint to plot, it can be: 'all', 'CTr', 'FTi', 'TiTa',or 'Claw'
-    """ 
+    """
 
     legs = list(errors_dict.keys())
     angles = list(errors_dict[legs[0]].keys())
     df_errors = pd.DataFrame()
-    
+
     joint_id = {'all': 0, 'CTr': 1, 'FTi': 2, 'TiTa': 3, 'Claw': 4}
-    
-    colors = [(204/255,0,0),(1,51/255,51/255),(1,102/255,102/255),(0,76/255,153/255),(0,0.5,1),(102/255,178/255,1)]
+
+    colors = [(204 /
+               255, 0, 0), (1, 51 /
+                            255, 51 /
+                            255), (1, 102 /
+                                   255, 102 /
+                                   255), (0, 76 /
+                                          255, 153 /
+                                          255), (0, 0.5, 1), (102 /
+                                                              255, 178 /
+                                                              255, 1)]
 
     if end == 0:
         end = len(errors_dict[legs[0]][angles[0]]['min_error']) * time_step
@@ -1763,165 +2328,245 @@ def plot_error(
     steps = 1 / time_step
     start = int(begin * steps)
     stop = int(end * steps)
-        
+
     for leg in legs:
         for angle in angles:
             vals = []
             for err in errors_dict[leg][angle]['min_error'][start:stop]:
-                mae = err[joint_id[joint]]/(len(err)-1)
-                norm_error = mae/BL*100
+                mae = err[joint_id[joint]] / (len(err) - 1)
+                norm_error = mae / BL * 100
                 vals.append(norm_error)
 
-            df_vals = pd.DataFrame(vals,columns=['norm_error'])
+            df_vals = pd.DataFrame(vals, columns=['norm_error'])
             df_vals['leg'] = leg
             df_vals['angle'] = angle
 
-            df_errors = df_errors.append(df_vals, ignore_index = True)
-    mean_vals=[]
-  
-    data = [df_errors.loc[ids, 'norm_error'].values for ids in df_errors.groupby('angle').groups.values()]
+            df_errors = df_errors.append(df_vals, ignore_index=True)
+    mean_vals = []
+
+    data = [df_errors.loc[ids, 'norm_error'].values for ids in df_errors.groupby(
+        'angle').groups.values()]
     stats.kruskal(*data)
-    ph=sp.posthoc_conover(df_errors, val_col='norm_error', group_col='angle', p_adjust = 'holm', sort=False)
-    ph_noDiff = ph.where(ph>0.001)
+    ph = sp.posthoc_conover(
+        df_errors,
+        val_col='norm_error',
+        group_col='angle',
+        p_adjust='holm',
+        sort=False)
+    ph_noDiff = ph.where(ph > 0.001)
     if save_results:
-        ph.to_csv(path_results+'/p-values_comparison_dofs.csv')
+        ph.to_csv(path_results + '/p-values_comparison_dofs.csv')
     else:
         print(ph_noDiff)
         print(ph)
-        
-    
+
     figure = plt.figure()
-    ax = sns.violinplot(x='angle', y='norm_error', data=df_errors, color="0.8", cut=0, inner='quartiles')
-    for violin, alpha in zip(ax.collections[::1], [0.7]*len(angles)):
+    ax = sns.violinplot(
+        x='angle',
+        y='norm_error',
+        data=df_errors,
+        color="0.8",
+        cut=0,
+        inner='quartiles')
+    for violin, alpha in zip(ax.collections[::1], [0.7] * len(angles)):
         violin.set_alpha(alpha)
-    ax = sns.stripplot(x='angle', y='norm_error', hue='leg', data=df_errors, dodge=split, jitter=True, zorder=0, size=3)
+    ax = sns.stripplot(
+        x='angle',
+        y='norm_error',
+        hue='leg',
+        data=df_errors,
+        dodge=split,
+        jitter=True,
+        zorder=0,
+        size=3)
     #ax = sns.swarmplot(x='angle', y='norm_error', hue='leg', data=df_errors, zorder=0, size=3)
     handles, labels = ax.get_legend_handles_labels()
     if split:
-        ax.legend(handles[len(angles)*len(legs):], labels[len(angles)*len(legs):],loc='upper right', bbox_to_anchor=(1.12, 1))
+        ax.legend(handles[len(angles) * len(legs):],
+                  labels[len(angles) * len(legs):],
+                  loc='upper right',
+                  bbox_to_anchor=(1.12,
+                                  1))
     else:
-        ax.legend(handles[len(angles):], labels[len(angles):],loc='upper right', bbox_to_anchor=(1.12, 1))
-    
+        ax.legend(handles[len(angles):], labels[len(angles):],
+                  loc='upper right', bbox_to_anchor=(1.12, 1))
+
     #plt.legend(loc='upper right', bbox_to_anchor=(1.12, 1))
-    plt.title('Comparison adding extra DoFs')  
+    plt.title('Comparison adding extra DoFs')
     plt.xlabel("")
-    plt.ylabel("MAE (% of body length)") 
+    plt.ylabel("MAE (% of body length)")
     plt.show()
 
     if save_results:
         fig_name = f"{path_results}/errors_comparison.png"
-        fig = plt.gcf()  
-        w_img = int(len(angles)*1.5)
-        h_img = int(w_img*3/4)
+        fig = plt.gcf()
+        w_img = int(len(angles) * 1.5)
+        h_img = int(w_img * 3 / 4)
         fig.set_size_inches(w_img, h_img)
         fig.savefig(fig_name)
 
-    
 
-def plot_error_old(errors_dict,begin=0,end=0,name='filename.png',dpi=300,split=False,save=False,BL=2.88,joint='all'):
+def plot_error_old(
+        errors_dict,
+        begin=0,
+        end=0,
+        name='filename.png',
+        dpi=300,
+        split=False,
+        save=False,
+        BL=2.88,
+        joint='all'):
     legs = list(errors_dict.keys())
     angles = list(errors_dict[legs[0]].keys())
     df_errors = pd.DataFrame()
-    
+
     joint_id = {'all': 0, 'CTr': 1, 'FTi': 2, 'TiTa': 3, 'Claw': 4}
-    
-    colors = [(204/255,0,0),(1,51/255,51/255),(1,102/255,102/255),(0,76/255,153/255),(0,0.5,1),(102/255,178/255,1)]
+
+    colors = [(204 /
+               255, 0, 0), (1, 51 /
+                            255, 51 /
+                            255), (1, 102 /
+                                   255, 102 /
+                                   255), (0, 76 /
+                                          255, 153 /
+                                          255), (0, 0.5, 1), (102 /
+                                                              255, 178 /
+                                                              255, 1)]
 
     if end == 0:
         end = len(errors_dict[legs[0]][angles[0]]['min_error'])
-        
+
     for leg in legs:
         for angle in angles:
             vals = []
             for err in errors_dict[leg][angle]['min_error'][begin:end]:
-                mae = err[joint_id[joint]]/(len(err)-1)
-                norm_error = mae/BL*100
+                mae = err[joint_id[joint]] / (len(err) - 1)
+                norm_error = mae / BL * 100
                 vals.append(norm_error)
 
-            df_vals = pd.DataFrame(vals,columns=['norm_error'])
+            df_vals = pd.DataFrame(vals, columns=['norm_error'])
             df_vals['leg'] = leg
             df_vals['angle'] = angle
 
-            df_errors = df_errors.append(df_vals, ignore_index = True)
-    mean_vals=[]
+            df_errors = df_errors.append(df_vals, ignore_index=True)
+    mean_vals = []
 
     #data = [e.loc[ids, 'norm_error'].values for ids in e.groupby('angle').groups.values()]
-    #stats.kruskal(*data)
+    # stats.kruskal(*data)
     #ph=sp.posthoc_conover(e, val_col='norm_error', group_col='angle', p_adjust = 'holm')
-    #ph.where(ph>0.01)
-    #stats.kruskal()
-    
-    
+    # ph.where(ph>0.01)
+    # stats.kruskal()
+
     for angle1 in angles:
-        x1 = df_errors['norm_error'].loc[df_errors['angle']==angle1]
-        #mean_vals.append(np.mean(x1))
-        print(angle1 + ' mean/std = ' + str(np.mean(x1)) + ' /+- ' + str(np.std(x1)))
-        for angle2 in angles[angles.index(angle1)+1:]:
-        #if angle != 'base':            
-            x2 = df_errors['norm_error'].loc[df_errors['angle']==angle2]
-            
-            ztest , pval = stests.ztest(x1, x2=x2, value=0, alternative='two-sided')
+        x1 = df_errors['norm_error'].loc[df_errors['angle'] == angle1]
+        # mean_vals.append(np.mean(x1))
+        print(angle1 +
+              ' mean/std = ' +
+              str(np.mean(x1)) +
+              ' /+- ' +
+              str(np.std(x1)))
+        for angle2 in angles[angles.index(angle1) + 1:]:
+            # if angle != 'base':
+            x2 = df_errors['norm_error'].loc[df_errors['angle'] == angle2]
+
+            ztest, pval = stests.ztest(
+                x1, x2=x2, value=0, alternative='two-sided')
 
             print(angle1 + ' vs ' + angle2 + ': ', ztest, pval,)
             if pval > 0.001:
                 print(angle1 + " is not statistically different from " + angle2)
         print()
-    
-    ax = sns.violinplot(x='angle', y='norm_error', data=df_errors, color="0.8", cut=0, inner='quartiles')
-    for violin, alpha in zip(ax.collections[::1], [0.7]*len(angles)):
+
+    ax = sns.violinplot(
+        x='angle',
+        y='norm_error',
+        data=df_errors,
+        color="0.8",
+        cut=0,
+        inner='quartiles')
+    for violin, alpha in zip(ax.collections[::1], [0.7] * len(angles)):
         violin.set_alpha(alpha)
-    ax = sns.stripplot(x='angle', y='norm_error', hue='leg', data=df_errors, dodge=split, jitter=True, zorder=0, size=3)
+    ax = sns.stripplot(
+        x='angle',
+        y='norm_error',
+        hue='leg',
+        data=df_errors,
+        dodge=split,
+        jitter=True,
+        zorder=0,
+        size=3)
     #ax = sns.swarmplot(x='angle', y='norm_error', hue='leg', data=df_errors, zorder=0, size=3)
     handles, labels = ax.get_legend_handles_labels()
     if split:
-        ax.legend(handles[len(angles)*len(legs):], labels[len(angles)*len(legs):],loc='upper right', bbox_to_anchor=(1.12, 1))
+        ax.legend(handles[len(angles) * len(legs):],
+                  labels[len(angles) * len(legs):],
+                  loc='upper right',
+                  bbox_to_anchor=(1.12,
+                                  1))
     else:
-        ax.legend(handles[len(angles):], labels[len(angles):],loc='upper right', bbox_to_anchor=(1.12, 1))
-    #ax.set_yscale('log')
-    #ax.set_ylim(0,6)
+        ax.legend(handles[len(angles):], labels[len(angles):],
+                  loc='upper right', bbox_to_anchor=(1.12, 1))
+    # ax.set_yscale('log')
+    # ax.set_ylim(0,6)
     #plt.plot(np.arange(len(mean_vals)), mean_vals, 'kP', markersize=10)
     plt.title(f'Comparison adding an extra DOF: {joint}')
-    
+
     figure = plt.gcf()  # get current figure
-    w_img = int(len(angles)*1.5)
-    h_img = int(w_img*3/4)
-    figure.set_size_inches(w_img, h_img) # set figure's size manually to your full screen (32x18)
+    w_img = int(len(angles) * 1.5)
+    h_img = int(w_img * 3 / 4)
+    # set figure's size manually to your full screen (32x18)
+    figure.set_size_inches(w_img, h_img)
     if save_results:
-        plt.savefig(name, dpi=dpi,bbox_inches='tight')
+        plt.savefig(name, dpi=dpi, bbox_inches='tight')
     plt.show()
-    
-    
+
     return df_errors
 
-def calculate_inverse_kinematics(data_dict, init_angles={},roll_tr=False):
+
+def calculate_inverse_kinematics(data_dict, init_angles={}, roll_tr=False):
     angles_ik = {}
-    
+
     for name, leg in data_dict.items():
         if roll_tr:
-            angles_ik[name]={'ThC_roll':[],'ThC_pitch':[],'ThC_yaw':[],'CTr_pitch':[],'CTr_roll':[],'FTi_pitch':[],'TiTa_pitch':[]}
+            angles_ik[name] = {
+                'ThC_roll': [],
+                'ThC_pitch': [],
+                'ThC_yaw': [],
+                'CTr_pitch': [],
+                'CTr_roll': [],
+                'FTi_pitch': [],
+                'TiTa_pitch': []}
         else:
-            angles_ik[name]={'ThC_roll':[],'ThC_pitch':[],'ThC_yaw':[],'CTr_pitch':[],'FTi_pitch':[],'TiTa_pitch':[]}
+            angles_ik[name] = {
+                'ThC_roll': [],
+                'ThC_pitch': [],
+                'ThC_yaw': [],
+                'CTr_pitch': [],
+                'FTi_pitch': [],
+                'TiTa_pitch': []}
         l_coxa = leg['Coxa']['mean_length']
         l_femur = leg['Femur']['mean_length']
         l_tibia = leg['Tibia']['mean_length']
         l_tarsus = leg['Tarsus']['mean_length']
         coxa_pos = leg['Coxa']['fixed_pos_aligned']
 
-        leg_chain = create_kinematic_chain(name,l_coxa,l_femur,l_tibia,l_tarsus,roll_tr)
+        leg_chain = create_kinematic_chain(
+            name, l_coxa, l_femur, l_tibia, l_tarsus, roll_tr)
 
         if not init_angles:
-            init_pos = [0]*len(leg_chain.links)
+            init_pos = [0] * len(leg_chain.links)
         else:
             init_pos = [0]
             for key in angles_ik[name].keys():
                 init_pos.append(init_angles[name][key][0])
-                    
+
             init_pos.append(0)
 
         for i, pos in enumerate(leg['Claw']['raw_pos_aligned']):
-            print('\r'+name+' frame: '+str(i),end='')
+            print('\r' + name + ' frame: ' + str(i), end='')
             pos_norm = pos - coxa_pos
-            angles = leg_chain.inverse_kinematics(pos_norm,initial_position=init_pos)
+            angles = leg_chain.inverse_kinematics(
+                pos_norm, initial_position=init_pos)
             angles_ik[name]['ThC_roll'].append(angles[1])
             angles_ik[name]['ThC_pitch'].append(angles[2])
             angles_ik[name]['ThC_yaw'].append(angles[3])
@@ -1936,240 +2581,274 @@ def calculate_inverse_kinematics(data_dict, init_angles={},roll_tr=False):
 
     return angles_ik
 
-def create_kinematic_chain(name,l_co,l_fe,l_ti,l_ta,roll_tr = False):
+
+def create_kinematic_chain(name, l_co, l_fe, l_ti, l_ta, roll_tr=False):
     if roll_tr:
-        leg_chain = Chain(name=name, links=[ 
-        OriginLink(), 
-        URDFLink( 
-          name="ThC_roll", 
-          translation_vector=[0, 0, 0], 
-          orientation=[0, 0, 0], 
-          rotation=[0, 0, 1], 
-        ), 
-        URDFLink( 
-          name="ThC_pitch", 
-          translation_vector=[0, 0, 0], 
-          orientation=[0, 0, 0], 
-          rotation=[0, 1, 0], 
-        ), 
-        URDFLink(  
-          name="ThC_yaw",  
-          translation_vector=[0, 0, 0],  
-          orientation=[0, 0, 0],  
-          rotation=[1, 0, 0],  
-        ), 
-        URDFLink(  
-          name="CTr_pitch",  
-          translation_vector=[0, 0, -l_co],  
-          orientation=[0, 0, 0],  
-          rotation=[0, 1, 0],  
-        ),
-        URDFLink(  
-          name="CTr_roll",  
-          translation_vector=[0, 0, 0],  
-          orientation=[0, 0, 0],  
-          rotation=[1, 0, 0],  
-        ),
-        URDFLink(  
-          name="FTi_pitch",  
-          translation_vector=[0, 0, -l_fe],  
-          orientation=[0, 0, 0],  
-          rotation=[0, 1, 0],  
-        ), 
-        URDFLink( 
-          name="TiTa_pitch", 
-          translation_vector=[0, 0, -l_ti], 
-          orientation=[0, 0, 0], 
-          rotation=[0, 1, 0], 
-        ), 
-        URDFLink(  
-          name="Claw",  
-          translation_vector=[0, 0, -l_ta],  
-          orientation=[0, 0, 0],  
-          rotation=[0, 0, 0],  
-        ), 
+        leg_chain = Chain(name=name, links=[
+            OriginLink(),
+            URDFLink(
+                name="ThC_roll",
+                translation_vector=[0, 0, 0],
+                orientation=[0, 0, 0],
+                rotation=[0, 0, 1],
+            ),
+            URDFLink(
+                name="ThC_pitch",
+                translation_vector=[0, 0, 0],
+                orientation=[0, 0, 0],
+                rotation=[0, 1, 0],
+            ),
+            URDFLink(
+                name="ThC_yaw",
+                translation_vector=[0, 0, 0],
+                orientation=[0, 0, 0],
+                rotation=[1, 0, 0],
+            ),
+            URDFLink(
+                name="CTr_pitch",
+                translation_vector=[0, 0, -l_co],
+                orientation=[0, 0, 0],
+                rotation=[0, 1, 0],
+            ),
+            URDFLink(
+                name="CTr_roll",
+                translation_vector=[0, 0, 0],
+                orientation=[0, 0, 0],
+                rotation=[1, 0, 0],
+            ),
+            URDFLink(
+                name="FTi_pitch",
+                translation_vector=[0, 0, -l_fe],
+                orientation=[0, 0, 0],
+                rotation=[0, 1, 0],
+            ),
+            URDFLink(
+                name="TiTa_pitch",
+                translation_vector=[0, 0, -l_ti],
+                orientation=[0, 0, 0],
+                rotation=[0, 1, 0],
+            ),
+            URDFLink(
+                name="Claw",
+                translation_vector=[0, 0, -l_ta],
+                orientation=[0, 0, 0],
+                rotation=[0, 0, 0],
+            ),
         ])
     else:
-        leg_chain = Chain(name=name, links=[ 
-        OriginLink(), 
-        URDFLink( 
-          name="ThC_roll", 
-          translation_vector=[0, 0, 0], 
-          orientation=[0, 0, 0], 
-          rotation=[0, 0, 1], 
-        ), 
-        URDFLink( 
-          name="ThC_pitch", 
-          translation_vector=[0, 0, 0], 
-          orientation=[0, 0, 0], 
-          rotation=[0, 1, 0], 
-        ), 
-        URDFLink(  
-          name="ThC_yaw",  
-          translation_vector=[0, 0, 0],  
-          orientation=[0, 0, 0],  
-          rotation=[1, 0, 0],  
-        ), 
-        URDFLink(  
-          name="CTr_pitch",  
-          translation_vector=[0, 0, -l_co],  
-          orientation=[0, 0, 0],  
-          rotation=[0, 1, 0],  
-        ),
-        URDFLink(  
-          name="FTi_pitch",  
-          translation_vector=[0, 0, -l_fe],  
-          orientation=[0, 0, 0],  
-          rotation=[0, 1, 0],  
-        ), 
-        URDFLink( 
-          name="TiTa_pitch", 
-          translation_vector=[0, 0, -l_ti], 
-          orientation=[0, 0, 0], 
-          rotation=[0, 1, 0], 
-        ), 
-        URDFLink(  
-          name="Claw",  
-          translation_vector=[0, 0, -l_ta],  
-          orientation=[0, 0, 0],  
-          rotation=[0, 0, 0],  
-        ), 
+        leg_chain = Chain(name=name, links=[
+            OriginLink(),
+            URDFLink(
+                name="ThC_roll",
+                translation_vector=[0, 0, 0],
+                orientation=[0, 0, 0],
+                rotation=[0, 0, 1],
+            ),
+            URDFLink(
+                name="ThC_pitch",
+                translation_vector=[0, 0, 0],
+                orientation=[0, 0, 0],
+                rotation=[0, 1, 0],
+            ),
+            URDFLink(
+                name="ThC_yaw",
+                translation_vector=[0, 0, 0],
+                orientation=[0, 0, 0],
+                rotation=[1, 0, 0],
+            ),
+            URDFLink(
+                name="CTr_pitch",
+                translation_vector=[0, 0, -l_co],
+                orientation=[0, 0, 0],
+                rotation=[0, 1, 0],
+            ),
+            URDFLink(
+                name="FTi_pitch",
+                translation_vector=[0, 0, -l_fe],
+                orientation=[0, 0, 0],
+                rotation=[0, 1, 0],
+            ),
+            URDFLink(
+                name="TiTa_pitch",
+                translation_vector=[0, 0, -l_ti],
+                orientation=[0, 0, 0],
+                rotation=[0, 1, 0],
+            ),
+            URDFLink(
+                name="Claw",
+                translation_vector=[0, 0, -l_ta],
+                orientation=[0, 0, 0],
+                rotation=[0, 0, 0],
+            ),
         ])
 
     return leg_chain
 
-def fk_from_ik(leg, name, data_dict, frame, roll_tr = False):
+
+def fk_from_ik(leg, name, data_dict, frame, roll_tr=False):
 
     l_coxa = data_dict[name]['Coxa']['mean_length']
     l_femur = data_dict[name]['Femur']['mean_length']
     l_tibia = data_dict[name]['Tibia']['mean_length']
     l_tarsus = data_dict[name]['Tarsus']['mean_length']
 
-    leg_chain = create_kinematic_chain(name,l_coxa,l_femur,l_tibia,l_tarsus,roll_tr)
-    
+    leg_chain = create_kinematic_chain(
+        name, l_coxa, l_femur, l_tibia, l_tarsus, roll_tr)
+
     if roll_tr:
-        vect = [0,leg['ThC_roll'][frame],leg['ThC_pitch'][frame],leg['ThC_yaw'][frame],leg['CTr_pitch'][frame],leg['CTr_roll_tr'][frame],leg['FTi_pitch'][frame],leg['TiTa_pitch'][frame],0]
+        vect = [
+            0,
+            leg['ThC_roll'][frame],
+            leg['ThC_pitch'][frame],
+            leg['ThC_yaw'][frame],
+            leg['CTr_pitch'][frame],
+            leg['CTr_roll_tr'][frame],
+            leg['FTi_pitch'][frame],
+            leg['TiTa_pitch'][frame],
+            0]
     else:
-        vect = [0,leg['ThC_roll'][frame],leg['ThC_pitch'][frame],leg['ThC_yaw'][frame],leg['CTr_pitch'][frame],leg['FTi_pitch'][frame],leg['TiTa_pitch'][frame],0]
+        vect = [
+            0,
+            leg['ThC_roll'][frame],
+            leg['ThC_pitch'][frame],
+            leg['ThC_yaw'][frame],
+            leg['CTr_pitch'][frame],
+            leg['FTi_pitch'][frame],
+            leg['TiTa_pitch'][frame],
+            0]
 
-    pred = leg_chain.forward_kinematics(vect,full_kinematics=True)
+    pred = leg_chain.forward_kinematics(vect, full_kinematics=True)
 
-    fe_init_pos = np.array([0,0,-l_coxa,1])
-    ti_init_pos = np.array([0,0,-l_femur,1])
-    ta_init_pos = np.array([0,0,-l_tibia,1])
-    claw_init_pos = np.array([0,0,-l_tarsus,1])
+    fe_init_pos = np.array([0, 0, -l_coxa, 1])
+    ti_init_pos = np.array([0, 0, -l_femur, 1])
+    ta_init_pos = np.array([0, 0, -l_tibia, 1])
+    claw_init_pos = np.array([0, 0, -l_tarsus, 1])
 
     real_pos_coxa = data_dict[name]['Coxa']['fixed_pos_aligned']
-    pred_coxa =  pred[3].transpose()[3][:3] + real_pos_coxa
-    pred_femur =  pred[4].transpose()[3][:3] + real_pos_coxa
+    pred_coxa = pred[3].transpose()[3][:3] + real_pos_coxa
+    pred_femur = pred[4].transpose()[3][:3] + real_pos_coxa
     pred_tibia = pred[5].transpose()[3][:3] + real_pos_coxa
     pred_tarsus = pred[6].transpose()[3][:3] + real_pos_coxa
     pred_claw = pred[7].transpose()[3][:3] + real_pos_coxa
-    
-    pred_pos = np.array([pred_coxa,pred_femur,pred_tibia,pred_tarsus,pred_claw])
+
+    pred_pos = np.array(
+        [pred_coxa, pred_femur, pred_tibia, pred_tarsus, pred_claw])
 
     return pred_pos
 
 
-def calculate_min_error(angles,data_dict,begin=0,end=0,extraDOF = ['base'],legs_to_check=[]):
+def calculate_min_error(
+        angles,
+        data_dict,
+        begin=0,
+        end=0,
+        extraDOF=['base'],
+        legs_to_check=[]):
     #extraKeys = ['roll_tr','yaw_tr','roll_ti','yaw_ti','roll_ta','yaw_ta']
 
     errors_dict = {}
-    
+
     if end == 0:
         end = len(angles['LF_leg']['ThC_yaw'])
 
     for frame in range(begin, end):
-        print('\rFrame: '+str(frame),end='')
+        print('\rFrame: ' + str(frame), end='')
 
         for name, leg in angles.items():
 
             if legs_to_check:
-                if not name in legs_to_check:
+                if name not in legs_to_check:
                     break
-                
-            if not name in errors_dict.keys():
+
+            if name not in errors_dict.keys():
                 errors_dict[name] = dict.fromkeys(extraDOF)
 
             for key in extraDOF:
                 if not errors_dict[name][key]:
-                    errors_dict[name][key] = {'min_error':[],'best_angle':[]}
-                
+                    errors_dict[name][key] = {
+                        'min_error': [], 'best_angle': []}
+
                 #coxa_pos = data_dict[name]['Coxa']['fixed_pos_aligned']
                 real_pos_femur = data_dict[name]['Femur']['raw_pos_aligned'][frame]
                 real_pos_tibia = data_dict[name]['Tibia']['raw_pos_aligned'][frame]
                 real_pos_tarsus = data_dict[name]['Tarsus']['raw_pos_aligned'][frame]
                 real_pos_claw = data_dict[name]['Claw']['raw_pos_aligned'][frame]
-            
-                min_error = [100000000,0,0,0,0]
+
+                min_error = [100000000, 0, 0, 0, 0]
                 best_angle = 0
                 if key == 'base':
-                    pos_3d = calculate_forward_kinematics(name, frame, leg, data_dict)
+                    pos_3d = calculate_forward_kinematics(
+                        name, frame, leg, data_dict)
                     #pos_3d = calculate_forward_kinematics(name, frame, leg, data_dict,extraDOF={'roll_tr':angles[name]['roll_tr'][frame]})
 
-                    d_fe = np.linalg.norm(pos_3d[1]-real_pos_femur)
-                    d_ti = np.linalg.norm(pos_3d[2]-real_pos_tibia) 
-                    d_ta = np.linalg.norm(pos_3d[3]-real_pos_tarsus)
-                    d_claw = np.linalg.norm(pos_3d[4]-real_pos_claw)
+                    d_fe = np.linalg.norm(pos_3d[1] - real_pos_femur)
+                    d_ti = np.linalg.norm(pos_3d[2] - real_pos_tibia)
+                    d_ta = np.linalg.norm(pos_3d[3] - real_pos_tarsus)
+                    d_claw = np.linalg.norm(pos_3d[4] - real_pos_claw)
 
                     d_tot = d_fe + d_ti + d_ta + d_claw
-                           
-                    errors_dict[name][key]['min_error'].append([d_tot,d_fe,d_ti,d_ta,d_claw])
+
+                    errors_dict[name][key]['min_error'].append(
+                        [d_tot, d_fe, d_ti, d_ta, d_claw])
                 elif key == 'base_CTr_roll':
                     #pos_3d = calculate_forward_kinematics(name, frame, leg, data_dict)
-                    pos_3d = calculate_forward_kinematics(name, frame, leg, data_dict,extraDOF={'CTr_roll':angles})
+                    pos_3d = calculate_forward_kinematics(
+                        name, frame, leg, data_dict, extraDOF={'CTr_roll': angles})
 
-                    d_fe = np.linalg.norm(pos_3d[1]-real_pos_femur)
-                    d_ti = np.linalg.norm(pos_3d[2]-real_pos_tibia) 
-                    d_ta = np.linalg.norm(pos_3d[3]-real_pos_tarsus)
-                    d_claw = np.linalg.norm(pos_3d[4]-real_pos_claw)
+                    d_fe = np.linalg.norm(pos_3d[1] - real_pos_femur)
+                    d_ti = np.linalg.norm(pos_3d[2] - real_pos_tibia)
+                    d_ta = np.linalg.norm(pos_3d[3] - real_pos_tarsus)
+                    d_claw = np.linalg.norm(pos_3d[4] - real_pos_claw)
 
                     d_tot = d_fe + d_ti + d_ta + d_claw
-                           
-                    errors_dict[name][key]['min_error'].append([d_tot,d_fe,d_ti,d_ta,d_claw])
+
+                    errors_dict[name][key]['min_error'].append(
+                        [d_tot, d_fe, d_ti, d_ta, d_claw])
                 elif key == 'IK':
                     pos_3d = fk_from_ik(leg, name, data_dict, frame)
 
-                    d_fe = np.linalg.norm(pos_3d[1]-real_pos_femur)
-                    d_ti = np.linalg.norm(pos_3d[2]-real_pos_tibia) 
-                    d_ta = np.linalg.norm(pos_3d[3]-real_pos_tarsus)
-                    d_claw = np.linalg.norm(pos_3d[4]-real_pos_claw)
+                    d_fe = np.linalg.norm(pos_3d[1] - real_pos_femur)
+                    d_ti = np.linalg.norm(pos_3d[2] - real_pos_tibia)
+                    d_ta = np.linalg.norm(pos_3d[3] - real_pos_tarsus)
+                    d_claw = np.linalg.norm(pos_3d[4] - real_pos_claw)
 
                     d_tot = d_fe + d_ti + d_ta + d_claw
-                           
-                    errors_dict[name][key]['min_error'].append([d_tot,d_fe,d_ti,d_ta,d_claw])
+
+                    errors_dict[name][key]['min_error'].append(
+                        [d_tot, d_fe, d_ti, d_ta, d_claw])
                 else:
                     for i in range(-180, 180):
-                        extra_angle = np.deg2rad(i/2)
-                        extra_dict = {key:extra_angle}
+                        extra_angle = np.deg2rad(i / 2)
+                        extra_dict = {key: extra_angle}
 
-                        pos_3d = calculate_forward_kinematics(name, frame, leg, data_dict,extraDOF=extra_dict)
+                        pos_3d = calculate_forward_kinematics(
+                            name, frame, leg, data_dict, extraDOF=extra_dict)
 
-                        d_fe = np.linalg.norm(pos_3d[1]-real_pos_femur)
-                        d_ti = np.linalg.norm(pos_3d[2]-real_pos_tibia) 
-                        d_ta = np.linalg.norm(pos_3d[3]-real_pos_tarsus)
-                        d_claw = np.linalg.norm(pos_3d[4]-real_pos_claw)
+                        d_fe = np.linalg.norm(pos_3d[1] - real_pos_femur)
+                        d_ti = np.linalg.norm(pos_3d[2] - real_pos_tibia)
+                        d_ta = np.linalg.norm(pos_3d[3] - real_pos_tarsus)
+                        d_claw = np.linalg.norm(pos_3d[4] - real_pos_claw)
 
                         d_tot = d_fe + d_ti + d_ta + d_claw
 
-                        if d_tot<min_error[0]:
-                            min_error = [d_tot,d_fe,d_ti,d_ta,d_claw]
+                        if d_tot < min_error[0]:
+                            min_error = [d_tot, d_fe, d_ti, d_ta, d_claw]
                             best_angle = extra_angle
 
-                    #print(frame,name,key)
+                    # print(frame,name,key)
                     errors_dict[name][key]['min_error'].append(min_error)
                     errors_dict[name][key]['best_angle'].append(best_angle)
-            
+
     return errors_dict
 
 
 '''
 #####Reorder dictionary
-new_errors = {}                                       
+new_errors = {}
 
-extraKeys = ['base','IK','roll_tr','yaw_tr','roll_ti','yaw_ti','roll_ta','yaw_ta'] 
-for name, leg in errors.items(): 
-    new_errors[name]={} 
-    for key in extraKeys: 
+extraKeys = ['base','IK','roll_tr','yaw_tr','roll_ti','yaw_ti','roll_ta','yaw_ta']
+for name, leg in errors.items():
+    new_errors[name]={}
+    for key in extraKeys:
         new_errors[name][key] = leg[key]
 '''

--- a/examples/outlier_correction.py
+++ b/examples/outlier_correction.py
@@ -1,0 +1,53 @@
+""" use this file to generate template oscillation from the pkl file """
+import os
+import matplotlib.pyplot as plt
+from df3dPostProcessing import df3dPostProcess
+
+directory = '/mnt/nas/GO/7cam/210805_aJO-GAL4xUAS-CsChr/Fly001/001_High/behData/images/df3d'
+file_name = 'pose_result__mnt_nas_GO_7cam_210805_aJO-GAL4xUAS-CsChr_Fly001_001_High_behData_images.pkl'
+
+experiment = os.path.join(directory, file_name)
+
+df3d = df3dPostProcess(
+    exp_dir=experiment,
+    skeleton='df3d',
+    calculate_3d=True,
+    outlier_correction=True
+    )
+
+aligned_data_corrected = df3d.align_to_template(interpolate=False, smoothing=False)
+
+
+df3d_no_correction = df3dPostProcess(
+    exp_dir=experiment,
+    skeleton='df3d',
+    calculate_3d=True,
+    outlier_correction=False
+    )
+
+aligned_data_wo_correction = df3d_no_correction.align_to_template(interpolate=False, smoothing=False)
+
+
+fig, (ax1, ax2, ax3) = plt.subplots(3,1, figsize=(5,6), sharex=True)
+
+leg = 'LF_leg'
+
+for joint in aligned_data_corrected[leg]:
+    ax1.plot(aligned_data_corrected[leg][joint]['raw_pos_aligned'][:,0], label=f'{joint} corrected')
+    ax1.plot(aligned_data_wo_correction[leg][joint]['raw_pos_aligned'][:,0], label=f'{joint} not corrected')
+    ax1.set_ylabel('x axis')
+
+    ax2.plot(aligned_data_corrected[leg][joint]['raw_pos_aligned'][:,1], label=f'{joint} corrected')
+    ax2.plot(aligned_data_wo_correction[leg][joint]['raw_pos_aligned'][:,1], label=f'{joint} not corrected')
+    ax2.set_ylabel('y axis')
+
+    ax3.plot(aligned_data_corrected[leg][joint]['raw_pos_aligned'][:,2], label=f'{joint} corrected')
+    ax3.plot(aligned_data_wo_correction[leg][joint]['raw_pos_aligned'][:,2], label=f'{joint} not corrected')
+    ax3.set_ylabel('z axis')
+    ax3.set_xlabel('Frames')
+
+plt.xlim(1600,1750)
+plt.suptitle('Left Front Leg')
+plt.legend()
+plt.tight_layout()
+plt.show()


### PR DESCRIPTION
Tested Florian's outlier correction method and added an example. Code checks if the lengths of leg segments vary much and then corrects those with high variation by finding the pair of cameras giving the smallest projection error and replacing the new keypoint position from these cameras with the outlier one. This method works as long as the triangulation is fine. If triangulation is erroneous from the start, then this method does not work. See _examples/outlier_correction.py_ for the usage.

Here is a plot of the corrected results:
![correction](https://user-images.githubusercontent.com/55179596/154732153-988c3f2d-d1db-4f81-a990-e3cc211258cf.png)
 