### PR TITLE
modify setup.py to make sure submodule utils is installed properly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="df3dPostProcessing",
     version="1.0",
-    packages=["df3dPostProcessing"],
+    packages=setuptools.find_packages(),
     author="Victor Lobato",
     author_email="victor.lobatorios@epfl.ch",
     description="Postprocessing functions for DeepFly3D results",


### PR DESCRIPTION
Using `packages=setuptools.find_packages()` instead of hardcoded `packages=["df3dPostProcessing"]` in `setuptools.setup(...)` ensures that `df3dPostProcessing.utils` is installed properly upon pip install.